### PR TITLE
ci: deploy `@battle/gamev2` at `/v2` of existing AWS CDK deployment with S3 + CloudFront

### DIFF
--- a/packages/gamev2/.gitignore
+++ b/packages/gamev2/.gitignore
@@ -1,0 +1,2 @@
+package.zip
+dist

--- a/packages/gamev2/package.json
+++ b/packages/gamev2/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "clean": "rm -rf node_modules dist"
+    "clean": "rm -rf node_modules dist",
+    "package": "rm -f package.zip && cd dist && zip -r ../package.zip ."
   },
   "dependencies": {
     "@babylonjs/core": "^9.0.0",

--- a/packages/gamev2/src/main.tsx
+++ b/packages/gamev2/src/main.tsx
@@ -1,51 +1,18 @@
-import { StrictMode, useEffect, useRef, useState } from 'react';
+import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BabylonJsProvider } from './ui/BabylonJsProvider';
 import { GameContextProvider } from './ui/GameContextProvider';
 import { CursorProvider } from './ui/CursorProvider';
 import { App } from './ui/App';
-import { parseMap, RenderMap } from './map/MapParser';
-import { createStubProvider } from './providers/StubGameProvider';
-import { GameProvider } from './providers/GameProvider';
-
-const MAP_URL = '/maps/small-2p.txt';
-
-type LoadedMap = {
-  renderMap: RenderMap;
-  provider: GameProvider;
-};
-
-function MapLoader({ children }: { children: (loaded: LoadedMap) => React.ReactNode }) {
-  const loadedRef = useRef<LoadedMap | null>(null);
-  const [loaded, setLoaded] = useState<LoadedMap | null>(null);
-
-  useEffect(() => {
-    if (loadedRef.current) {
-      setLoaded(loadedRef.current);
-      return;
-    }
-
-    fetch(MAP_URL)
-      .then((r) => r.text())
-      .then((text) => {
-        const renderMap = parseMap(text);
-        const provider = createStubProvider(renderMap);
-        loadedRef.current = { renderMap, provider };
-        setLoaded(loadedRef.current);
-      });
-  }, []);
-
-  if (!loaded) return null;
-  return <>{children(loaded)}</>;
-}
+import { MapLoader } from './ui/MapLoader';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <MapLoader>
-      {({ renderMap, provider }) => (
+      {({ assetLoader, renderMap, provider }) => (
         <CursorProvider>
           <BabylonJsProvider>
-            <GameContextProvider provider={provider} renderMap={renderMap}>
+            <GameContextProvider assetLoader={assetLoader} provider={provider} renderMap={renderMap}>
               <App />
             </GameContextProvider>
           </BabylonJsProvider>

--- a/packages/gamev2/src/rendering/AssetLoader.ts
+++ b/packages/gamev2/src/rendering/AssetLoader.ts
@@ -1,4 +1,4 @@
-import { AbstractMesh, Scene, SceneLoader, Vector3 } from '@babylonjs/core';
+import { AbstractMesh, SceneLoader, Tools, Vector3 } from '@babylonjs/core';
 import '@babylonjs/loaders/glTF';
 import { TileType } from './TerritoryComposition';
 
@@ -19,13 +19,17 @@ const TILE_TYPE_FILES: Partial<Record<TileType, string>> = {
 export class AssetLoader {
   private templates = new Map<TileType, AbstractMesh>();
 
-  constructor(private readonly scene: Scene) { }
+  constructor(private readonly baseUrl: string) { }
+
+  async load(filename: string): Promise<string> {
+    return Tools.LoadFileAsync(this.baseUrl + filename, false)
+  }
 
   async loadAll(): Promise<void> {
     for (const [tileType, filename] of Object.entries(TILE_TYPE_FILES)) {
       if (this.templates.has(tileType as TileType)) continue;
 
-      const imported = await SceneLoader.ImportMeshAsync('', filename, undefined, undefined, undefined, '.glb');
+      const imported = await SceneLoader.ImportMeshAsync('', this.baseUrl + filename, undefined, undefined, undefined, '.glb');
       const mesh = imported.meshes.find((m) => m.name === '__root__');
       if (!mesh) throw new Error(`No __root__ in ${filename}`);
 

--- a/packages/gamev2/src/rendering/GameRenderer.ts
+++ b/packages/gamev2/src/rendering/GameRenderer.ts
@@ -32,11 +32,11 @@ export class GameRenderer {
   // territory ID → hex coord, for camera focus
   private territoryCoordMap = new Map<ID, HexCoord>();
 
-  constructor(scene: Scene, camera: ArcRotateCamera) {
+  constructor(scene: Scene, camera: ArcRotateCamera, assetLoader: AssetLoader) {
     this.sceneRenderer = new SceneRenderer(scene, camera);
     this.cameraController = new CameraController(camera);
     this.grid = new HexGridController(scene);
-    this.assetLoader = new AssetLoader(scene);
+    this.assetLoader = assetLoader;
     this.mapRenderer = new MapRenderer(scene, this.grid, this.assetLoader);
     this.unitRenderer = new UnitRenderer(scene, this.grid, this.territoryCoordMap);
     this.unitRenderer.onMeshRegistration((mesh) => this.sceneRenderer.registerMeshes([mesh]));

--- a/packages/gamev2/src/ui/GameContextProvider.tsx
+++ b/packages/gamev2/src/ui/GameContextProvider.tsx
@@ -7,6 +7,7 @@ import { GameRenderer } from '../rendering/GameRenderer';
 import { GameProvider } from '../providers/GameProvider';
 import { RenderMap } from '../map/MapParser';
 import { useBabylonJs } from './BabylonJsProvider';
+import { AssetLoader } from '../rendering';
 
 export const GameStoreContext = createContext<GameStore | null>(null);
 export const UserActionDispatchContext = createContext<UserActionDispatch | null>(null);
@@ -14,6 +15,7 @@ export const UserActionDispatchContext = createContext<UserActionDispatch | null
 type GameContextProviderProps = {
   provider: GameProvider;
   renderMap: RenderMap;
+  assetLoader: AssetLoader;
   children: ReactNode;
 };
 
@@ -22,7 +24,7 @@ type GameContextProviderProps = {
  * then provides GameStoreContext and UserActionDispatchContext to children.
  * Uses a ref to ensure only one orchestrator is created even under StrictMode double-mount.
  */
-export function GameContextProvider({ provider, renderMap, children }: GameContextProviderProps) {
+export function GameContextProvider({ provider, renderMap, assetLoader, children }: GameContextProviderProps) {
   const { scene, camera } = useBabylonJs();
   const orchestratorRef = useRef<GameOrchestrator | null>(null);
   const [orchestrator, setOrchestrator] = useState<GameOrchestrator | null>(null);
@@ -33,7 +35,7 @@ export function GameContextProvider({ provider, renderMap, children }: GameConte
       return;
     }
 
-    const renderer = new GameRenderer(scene, camera as ArcRotateCamera);
+    const renderer = new GameRenderer(scene, camera as ArcRotateCamera, assetLoader);
 
     const store = new GameStore({
       game: null!,

--- a/packages/gamev2/src/ui/MapLoader.tsx
+++ b/packages/gamev2/src/ui/MapLoader.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useRef, useState } from 'react';
+import { parseMap, RenderMap } from '../map/MapParser';
+import { createStubProvider } from '../providers/StubGameProvider';
+import { GameProvider } from '../providers/GameProvider';
+import { AssetLoader } from '../rendering';
+
+const MAP_URL = '/maps/small-2p.txt';
+
+type LoadedMap = {
+  assetLoader: AssetLoader;
+  renderMap: RenderMap;
+  provider: GameProvider;
+};
+
+export function MapLoader({ children }: { children: (loaded: LoadedMap) => React.ReactNode }) {
+  const loadedRef = useRef<LoadedMap | null>(null);
+  const [loaded, setLoaded] = useState<LoadedMap | null>(null);
+
+  useEffect(() => {
+    if (loadedRef.current) {
+      setLoaded(loadedRef.current);
+      return;
+    }
+
+    // determine base url, stripping any ending slash
+    const baseUrl = new URL('.', window.location.href).href.replace(/\/$/, '')
+
+    const assetLoader = new AssetLoader(baseUrl);
+
+    assetLoader.load(MAP_URL)
+      .then((text) => {
+        const renderMap = parseMap(text);
+        const provider = createStubProvider(renderMap);
+        loadedRef.current = { assetLoader, renderMap, provider };
+        setLoaded(loadedRef.current);
+      });
+  }, []);
+
+  if (!loaded) return null;
+  return <>{children(loaded)}</>;
+}

--- a/packages/gamev2/vite.config.ts
+++ b/packages/gamev2/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  base: '/v2/',
   optimizeDeps: {
     include: ['@battles/models'],
   },

--- a/packages/ops/lib/app-stack.ts
+++ b/packages/ops/lib/app-stack.ts
@@ -6,7 +6,8 @@ import * as route53targets from "@aws-cdk/aws-route53-targets";
 import * as s3 from "@aws-cdk/aws-s3";
 import * as s3deployment from "@aws-cdk/aws-s3-deployment";
 
-const DEPLOYMENT_ARTIFACT = "../game/package.zip";
+const DEPLOYMENT_ARTIFACT_GAME = "../game/package.zip";
+const DEPLOYMENT_ARTIFACT_GAME_V2 = "../gamev2/package.zip";
 
 export class AppStack extends cdk.Stack {
   constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
@@ -47,16 +48,29 @@ export class AppStack extends cdk.Stack {
       }),
     });
 
-    new s3deployment.BucketDeployment(this, "DeployApp", {
-      sources: [s3deployment.Source.asset(DEPLOYMENT_ARTIFACT)],
-      destinationBucket: bucket,
-      distribution,
-    });
-
     new route53.ARecord(this, "AliasRecord", {
       zone,
       recordName: hostname,
       target: route53.RecordTarget.fromAlias(new route53targets.CloudFrontTarget(distribution)),
     });
+
+    /*
+     * * * * * * * * * * * * * * * * * * *
+     * App deployments
+     */
+
+    new s3deployment.BucketDeployment(this, "DeployApp", {
+      sources: [s3deployment.Source.asset(DEPLOYMENT_ARTIFACT_GAME)],
+      destinationBucket: bucket,
+      distribution,
+      exclude: ["v2/*"]
+    });
+
+    new s3deployment.BucketDeployment(this, "DeployGameV2", {
+      sources: [s3deployment.Source.asset(DEPLOYMENT_ARTIFACT_GAME_V2)],
+      destinationBucket: bucket,
+      destinationKeyPrefix: "v2/",
+      distribution,
+    })
   }
 }

--- a/packages/ops/lib/pipeline-stack.ts
+++ b/packages/ops/lib/pipeline-stack.ts
@@ -40,6 +40,8 @@ export class PipelineStack extends cdk.Stack {
           "yarn workspace @battles/api test",
           "yarn workspace @battles/game bundle:client",
           "yarn workspace @battles/game package",
+          "yarn workspace @battles/gamev2 build",
+          "yarn workspace @battles/gamev2 package",
           "yarn workspace @battles/ops cdk synth",
         ],
         primaryOutputDirectory: "packages/ops/cdk.out",


### PR DESCRIPTION
## Purpose 🎯 

Deploy `@battle/gamev2` alongside existing `@battle/game` app on `battles.tomwwright.com`

## Context 💭 

The app deployments could be moved to AWS Amplify, like https://github.com/tomwwright/babylonjs-tech-demo

But using what is already set up while it is here