### PR TITLE
chore: update AWS CDK to v2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine as build
+FROM node:24-alpine as build
 
 WORKDIR /app
 
@@ -15,7 +15,7 @@ RUN yarn workspace @battles/api build
 
 # AWS Lambda container image
 
-FROM public.ecr.aws/lambda/nodejs:14
+FROM public.ecr.aws/lambda/nodejs:24
 
 COPY --from=build /app/packages/api/dist ${LAMBDA_TASK_ROOT}/packages/api/dist
 COPY --from=build /app/packages/api/package.json ${LAMBDA_TASK_ROOT}/packages/api/package.json

--- a/package.json
+++ b/package.json
@@ -10,7 +10,12 @@
   "scripts": {
     "build": "tsc --build --verbose"
   },
-  "workspaces": [
-    "packages/*"
-  ]
+  "workspaces": {
+    "packages": [
+      "packages/*"
+    ],
+    "nohoist": [
+      "@battles/game/**"
+    ]
+  }
 }

--- a/packages/api/Dockerfile
+++ b/packages/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/nodejs:14
+FROM public.ecr.aws/lambda/nodejs:24
 
 RUN npm install -g yarn
 COPY package.json yarn.lock ${LAMBDA_TASK_ROOT}

--- a/packages/game/webpack.config.js
+++ b/packages/game/webpack.config.js
@@ -18,9 +18,9 @@ module.exports = {
     modules: ['node_modules', path.resolve(__dirname, 'build/es5')],
 
     alias: {
-      pixi: path.join(__dirname, '../../node_modules/phaser-ce/build/custom/pixi.js'),
-      'phaser-ce': path.join(__dirname, '../../node_modules/phaser-ce/build/custom/phaser-split.js'),
-      p2: path.join(__dirname, '../../node_modules/phaser-ce/build/custom/p2.js'),
+      pixi: path.join(__dirname, 'node_modules/phaser-ce/build/custom/pixi.js'),
+      'phaser-ce': path.join(__dirname, 'node_modules/phaser-ce/build/custom/phaser-split.js'),
+      p2: path.join(__dirname, 'node_modules/phaser-ce/build/custom/p2.js'),
     },
   },
 

--- a/packages/ops/.tool-versions
+++ b/packages/ops/.tool-versions
@@ -1,1 +1,1 @@
-nodejs lts
+nodejs 24.14.1

--- a/packages/ops/bin/ops.ts
+++ b/packages/ops/bin/ops.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import "source-map-support/register";
-import * as cdk from "@aws-cdk/core";
+import * as cdk from "aws-cdk-lib";
+import { Construct } from "constructs";
 
 import { ApiStack } from "../lib/api-stack";
 import { AppStack } from "../lib/app-stack";
@@ -15,7 +16,7 @@ const env = {
 const app = new cdk.App();
 
 export class ApplicationStage extends cdk.Stage {
-  constructor(scope: cdk.Construct, id: string, props?: cdk.StageProps) {
+  constructor(scope: Construct, id: string, props?: cdk.StageProps) {
     super(scope, id, props);
 
     new ApiStack(this, "Api", {

--- a/packages/ops/cdk.json
+++ b/packages/ops/cdk.json
@@ -1,19 +1,4 @@
 {
   "app": "npx ts-node --prefer-ts-exts bin/ops.ts",
-  "context": {
-    "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
-    "@aws-cdk/core:enableStackNameDuplicates": "true",
-    "aws-cdk:enableDiffNoFail": "true",
-    "@aws-cdk/core:newStyleStackSynthesis": true,
-    "@aws-cdk/core:stackRelativeExports": "true",
-    "@aws-cdk/aws-ecr-assets:dockerIgnoreSupport": true,
-    "@aws-cdk/aws-secretsmanager:parseOwnedSecretName": true,
-    "@aws-cdk/aws-kms:defaultKeyPolicies": true,
-    "@aws-cdk/aws-s3:grantWriteWithoutAcl": true,
-    "@aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount": true,
-    "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
-    "@aws-cdk/aws-efs:defaultEncryptionAtRest": true,
-    "@aws-cdk/aws-lambda:recognizeVersionProps": true,
-    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true
-  }
+  "context": {}
 }

--- a/packages/ops/lib/api-stack.ts
+++ b/packages/ops/lib/api-stack.ts
@@ -1,12 +1,13 @@
-import * as cdk from "@aws-cdk/core";
-import * as apigateway from "@aws-cdk/aws-apigatewayv2";
-import * as apigatewayIntegrations from "@aws-cdk/aws-apigatewayv2-integrations";
-import * as dynamodb from "@aws-cdk/aws-dynamodb";
-import * as lambda from "@aws-cdk/aws-lambda";
+import * as cdk from "aws-cdk-lib";
+import * as apigateway from "aws-cdk-lib/aws-apigatewayv2";
+import * as apigatewayIntegrations from "aws-cdk-lib/aws-apigatewayv2-integrations";
+import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import { Construct } from "constructs";
 import * as path from "path";
 
 export class ApiStack extends cdk.Stack {
-  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
     const table = new dynamodb.Table(this, "Table", {

--- a/packages/ops/lib/app-stack.ts
+++ b/packages/ops/lib/app-stack.ts
@@ -1,16 +1,18 @@
-import * as cdk from "@aws-cdk/core";
-import * as acm from "@aws-cdk/aws-certificatemanager";
-import * as cloudfront from "@aws-cdk/aws-cloudfront";
-import * as route53 from "@aws-cdk/aws-route53";
-import * as route53targets from "@aws-cdk/aws-route53-targets";
-import * as s3 from "@aws-cdk/aws-s3";
-import * as s3deployment from "@aws-cdk/aws-s3-deployment";
+import * as cdk from "aws-cdk-lib";
+import * as acm from "aws-cdk-lib/aws-certificatemanager";
+import * as cloudfront from "aws-cdk-lib/aws-cloudfront";
+import * as origins from "aws-cdk-lib/aws-cloudfront-origins";
+import * as route53 from "aws-cdk-lib/aws-route53";
+import * as route53targets from "aws-cdk-lib/aws-route53-targets";
+import * as s3 from "aws-cdk-lib/aws-s3";
+import * as s3deployment from "aws-cdk-lib/aws-s3-deployment";
+import { Construct } from "constructs";
 
 const DEPLOYMENT_ARTIFACT_GAME = "../game/package.zip";
 const DEPLOYMENT_ARTIFACT_GAME_V2 = "../gamev2/package.zip";
 
 export class AppStack extends cdk.Stack {
-  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
     const domain = "tomwwright.com";
@@ -18,34 +20,22 @@ export class AppStack extends cdk.Stack {
 
     const bucket = new s3.Bucket(this, "Bucket");
 
-    const originAccessIdentity = new cloudfront.OriginAccessIdentity(this, "OIA", {
-      comment: "Setup read access from CloudFront to the bucket",
-    });
-    bucket.grantRead(originAccessIdentity);
-
     const zone = route53.HostedZone.fromLookup(this, "LookupHostedZone", {
       domainName: domain,
     });
 
-    const certificate = new acm.DnsValidatedCertificate(this, "Certificate", {
+    const certificate = new acm.Certificate(this, "Certificate", {
       domainName: hostname,
-      hostedZone: zone,
+      validation: acm.CertificateValidation.fromDns(zone),
     });
 
-    const distribution = new cloudfront.CloudFrontWebDistribution(this, "Distribution", {
+    const distribution = new cloudfront.Distribution(this, "Distribution", {
       defaultRootObject: "lobby.html",
-      originConfigs: [
-        {
-          s3OriginSource: {
-            s3BucketSource: bucket,
-            originAccessIdentity: originAccessIdentity,
-          },
-          behaviors: [{ isDefaultBehavior: true }],
-        },
-      ],
-      viewerCertificate: cloudfront.ViewerCertificate.fromAcmCertificate(certificate, {
-        aliases: [hostname],
-      }),
+      defaultBehavior: {
+        origin: origins.S3BucketOrigin.withOriginAccessControl(bucket),
+      },
+      domainNames: [hostname],
+      certificate,
     });
 
     new route53.ARecord(this, "AliasRecord", {

--- a/packages/ops/lib/pipeline-stack.ts
+++ b/packages/ops/lib/pipeline-stack.ts
@@ -1,10 +1,12 @@
-import * as cdk from "@aws-cdk/core";
-import * as iam from "@aws-cdk/aws-iam";
-import * as pipelines from "@aws-cdk/pipelines";
-import * as ssm from "@aws-cdk/aws-ssm";
+import * as cdk from "aws-cdk-lib";
+import * as iam from "aws-cdk-lib/aws-iam";
+import * as pipelines from "aws-cdk-lib/pipelines";
+import * as ssm from "aws-cdk-lib/aws-ssm";
+import { Construct } from "constructs";
+
 export class PipelineStack extends cdk.Stack {
   public readonly pipeline: pipelines.CodePipeline;
-  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
     const connectionArnParameter = ssm.StringParameter.fromStringParameterName(

--- a/packages/ops/lib/pipeline-stack.ts
+++ b/packages/ops/lib/pipeline-stack.ts
@@ -3,6 +3,7 @@ import * as iam from "aws-cdk-lib/aws-iam";
 import * as pipelines from "aws-cdk-lib/pipelines";
 import * as ssm from "aws-cdk-lib/aws-ssm";
 import { Construct } from "constructs";
+import { ComputeType } from "aws-cdk-lib/aws-codebuild";
 
 export class PipelineStack extends cdk.Stack {
   public readonly pipeline: pipelines.CodePipeline;
@@ -49,6 +50,9 @@ export class PipelineStack extends cdk.Stack {
         primaryOutputDirectory: "packages/ops/cdk.out",
       }),
       synthCodeBuildDefaults: {
+        buildEnvironment: {
+          computeType: ComputeType.MEDIUM,
+        },
         rolePolicy: rolePolicyStatements,
       },
     });

--- a/packages/ops/package.json
+++ b/packages/ops/package.json
@@ -12,25 +12,17 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "1.138.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^20.0.0",
-    "aws-cdk": "1.138.0",
+    "aws-cdk": "^2.248.0",
     "jest": "^30.0.0",
     "ts-jest": "^29.4.6",
     "tsx": "^4.21.0",
     "typescript": "^6.0.0"
   },
   "dependencies": {
-    "@aws-cdk/aws-apigatewayv2": "1.138.0",
-    "@aws-cdk/aws-apigatewayv2-integrations": "1.138.0",
-    "@aws-cdk/aws-cloudfront": "1.138.0",
-    "@aws-cdk/aws-dynamodb": "1.138.0",
-    "@aws-cdk/aws-lambda": "1.138.0",
-    "@aws-cdk/aws-route53-targets": "1.138.0",
-    "@aws-cdk/aws-s3-deployment": "1.138.0",
-    "@aws-cdk/core": "1.138.0",
-    "@aws-cdk/pipelines": "1.138.0",
+    "aws-cdk-lib": "^2.248.0",
+    "constructs": "^10.0.0",
     "source-map-support": "^0.5.16"
   }
 }

--- a/packages/ops/test/ops.test.ts
+++ b/packages/ops/test/ops.test.ts
@@ -1,5 +1,5 @@
-import { expect as expectCDK, matchTemplate, MatchStyle } from '@aws-cdk/assert';
-import * as cdk from '@aws-cdk/core';
+import { Template } from 'aws-cdk-lib/assertions';
+import * as cdk from 'aws-cdk-lib';
 import * as Ops from '../lib/api-stack';
 
 test('Empty Stack', () => {
@@ -7,12 +7,8 @@ test('Empty Stack', () => {
   // WHEN
   const stack = new Ops.ApiStack(app, 'MyTestStack');
   // THEN
-  expectCDK(stack).to(
-    matchTemplate(
-      {
-        Resources: {},
-      },
-      MatchStyle.EXACT
-    )
-  );
+  const template = Template.fromStack(stack);
+  template.templateMatches({
+    Resources: {},
+  });
 });

--- a/specs/aws-cdk-v2.md
+++ b/specs/aws-cdk-v2.md
@@ -1,0 +1,179 @@
+# AWS CDK v1 to v2 Migration Plan
+
+## Overview
+
+Migrate `packages/ops` from AWS CDK v1 (1.138.0) to AWS CDK v2. CDK v1 has been in maintenance mode since June 2023 and is end-of-life.
+
+The main structural change in CDK v2 is that all AWS construct libraries are consolidated into a single `aws-cdk-lib` package, and the `constructs` package is a separate peer dependency.
+
+## Current State
+
+- **CDK version**: v1 (1.138.0) across all `@aws-cdk/*` packages
+- **Note**: `aws-cdk-lib` ^2.0.0 is already listed in dependencies but unused
+- **Files to migrate**: 5 source files + package.json + cdk.json
+
+### Source files and their CDK imports
+
+| File | v1 packages used |
+|------|-----------------|
+| `bin/ops.ts` | `@aws-cdk/core` |
+| `lib/app-stack.ts` | `@aws-cdk/core`, `aws-certificatemanager`, `aws-cloudfront`, `aws-route53`, `aws-route53-targets`, `aws-s3`, `aws-s3-deployment` |
+| `lib/api-stack.ts` | `@aws-cdk/core`, `aws-apigatewayv2`, `aws-apigatewayv2-integrations`, `aws-dynamodb`, `aws-lambda` |
+| `lib/pipeline-stack.ts` | `@aws-cdk/core`, `aws-iam`, `aws-ssm`, `@aws-cdk/pipelines` |
+| `test/ops.test.ts` | `@aws-cdk/assert`, `@aws-cdk/core` |
+
+---
+
+## Step 1: Update dependencies in `package.json`
+
+**Remove** all v1 `@aws-cdk/*` packages from `dependencies` and `devDependencies`:
+- `@aws-cdk/core`
+- `@aws-cdk/aws-apigatewayv2`
+- `@aws-cdk/aws-apigatewayv2-integrations`
+- `@aws-cdk/aws-cloudfront`
+- `@aws-cdk/aws-dynamodb`
+- `@aws-cdk/aws-lambda`
+- `@aws-cdk/aws-route53-targets`
+- `@aws-cdk/aws-s3-deployment`
+- `@aws-cdk/pipelines`
+- `@aws-cdk/assert`
+
+**Add/update**:
+- `aws-cdk-lib` (already present at `^2.0.0` -- keep or pin to a recent version e.g. `^2.180.0`)
+- `constructs` `^10.0.0` (new peer dependency required by CDK v2)
+- `aws-cdk` in devDependencies: upgrade from `1.138.0` to `^2.180.0`
+
+**Keep**: `source-map-support`, all non-CDK dev deps unchanged.
+
+## Step 2: Update imports in all source files
+
+All `@aws-cdk/aws-*` imports become submodule imports from `aws-cdk-lib`. The `Construct` type moves to the `constructs` package.
+
+| v1 import | v2 import |
+|-----------|-----------|
+| `@aws-cdk/core` | `aws-cdk-lib` |
+| `@aws-cdk/aws-certificatemanager` | `aws-cdk-lib/aws-certificatemanager` |
+| `@aws-cdk/aws-cloudfront` | `aws-cdk-lib/aws-cloudfront` |
+| `@aws-cdk/aws-route53` | `aws-cdk-lib/aws-route53` |
+| `@aws-cdk/aws-route53-targets` | `aws-cdk-lib/aws-route53-targets` |
+| `@aws-cdk/aws-s3` | `aws-cdk-lib/aws-s3` |
+| `@aws-cdk/aws-s3-deployment` | `aws-cdk-lib/aws-s3-deployment` |
+| `@aws-cdk/aws-apigatewayv2` | `aws-cdk-lib/aws-apigatewayv2` |
+| `@aws-cdk/aws-apigatewayv2-integrations` | `aws-cdk-lib/aws-apigatewayv2-integrations` |
+| `@aws-cdk/aws-dynamodb` | `aws-cdk-lib/aws-dynamodb` |
+| `@aws-cdk/aws-lambda` | `aws-cdk-lib/aws-lambda` |
+| `@aws-cdk/aws-iam` | `aws-cdk-lib/aws-iam` |
+| `@aws-cdk/aws-ssm` | `aws-cdk-lib/aws-ssm` |
+| `@aws-cdk/pipelines` | `aws-cdk-lib/pipelines` |
+| `@aws-cdk/assert` | `aws-cdk-lib/assertions` |
+
+Additionally, all usages of `cdk.Construct` as a type (in constructor parameters) must change to `Construct` from the `constructs` package:
+
+```ts
+// Before
+import * as cdk from "@aws-cdk/core";
+class MyStack extends cdk.Stack {
+  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+
+// After
+import * as cdk from "aws-cdk-lib";
+import { Construct } from "constructs";
+class MyStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+```
+
+## Step 3: Handle deprecated/changed constructs
+
+### `DnsValidatedCertificate` (app-stack.ts)
+
+`acm.DnsValidatedCertificate` is deprecated in CDK v2. Replace with `acm.Certificate` with `validation`:
+
+```ts
+// Before
+const certificate = new acm.DnsValidatedCertificate(this, "Certificate", {
+  domainName: hostname,
+  hostedZone: zone,
+});
+
+// After
+const certificate = new acm.Certificate(this, "Certificate", {
+  domainName: hostname,
+  validation: acm.CertificateValidation.fromDns(zone),
+});
+```
+
+### `CloudFrontWebDistribution` (app-stack.ts)
+
+`cloudfront.CloudFrontWebDistribution` still works in CDK v2 but is considered legacy. Optionally migrate to the newer `cloudfront.Distribution` API. This is **not required** for the v2 upgrade but is recommended:
+
+```ts
+// Before
+const distribution = new cloudfront.CloudFrontWebDistribution(this, "Distribution", {
+  defaultRootObject: "lobby.html",
+  originConfigs: [{ s3OriginSource: { ... }, behaviors: [{ isDefaultBehavior: true }] }],
+  viewerCertificate: cloudfront.ViewerCertificate.fromAcmCertificate(certificate, { aliases: [hostname] }),
+});
+
+// After (requires aws-cdk-lib/aws-cloudfront-origins)
+import * as origins from "aws-cdk-lib/aws-cloudfront-origins";
+
+const distribution = new cloudfront.Distribution(this, "Distribution", {
+  defaultRootObject: "lobby.html",
+  defaultBehavior: {
+    origin: origins.S3BucketOrigin.withOriginAccessControl(bucket),
+  },
+  domainNames: [hostname],
+  certificate,
+});
+```
+
+**Decision needed**: migrate CloudFront to the new `Distribution` API now, or keep `CloudFrontWebDistribution` for a smaller diff? Both work in v2. Migrating to `Distribution` will also eliminate the manual `OriginAccessIdentity` in favour of the newer Origin Access Control (OAC) pattern.
+
+### Test assertions (test/ops.test.ts)
+
+The `@aws-cdk/assert` package is replaced by `aws-cdk-lib/assertions` with a different API:
+
+```ts
+// Before
+import { expect as expectCDK, matchTemplate, MatchStyle } from "@aws-cdk/assert";
+expectCDK(stack).to(matchTemplate({}, MatchStyle.EXACT));
+
+// After
+import { Template } from "aws-cdk-lib/assertions";
+const template = Template.fromStack(stack);
+template.templateMatches({});
+```
+
+## Step 4: Update `cdk.json`
+
+Remove all v1 feature flags from the `context` block. These are the default behaviour in CDK v2 and are no longer needed:
+
+- `@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId`
+- `@aws-cdk/core:enableStackNameDuplicates`
+- `aws-cdk:enableDiffNoFail`
+- `@aws-cdk/core:newStyleStackSynthesis`
+- `@aws-cdk/core:stackRelativeExports`
+- `@aws-cdk/aws-ecr-assets:dockerIgnoreSupport`
+- `@aws-cdk/aws-secretsmanager:parseOwnedSecretName`
+- `@aws-cdk/aws-kms:defaultKeyPolicies`
+- `@aws-cdk/aws-s3:grantWriteWithoutAcl`
+- `@aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount`
+- `@aws-cdk/aws-rds:lowercaseDbIdentifier`
+- `@aws-cdk/aws-efs:defaultEncryptionAtRest`
+- `@aws-cdk/aws-lambda:recognizeVersionProps`
+- `@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021`
+
+The `app` entry can remain as-is (`npx ts-node --prefer-ts-exts bin/ops.ts`).
+
+## Step 5: Install and verify
+
+1. Run `yarn install` to resolve the new dependency tree
+2. Run `yarn workspace @battles/ops build` to verify TypeScript compilation
+3. Run `yarn workspace @battles/ops test` to verify tests pass
+4. Run `yarn workspace @battles/ops cdk synth` to verify CloudFormation output
+5. Run `yarn workspace @battles/ops cdk diff` against the deployed stack to confirm no unintended infrastructure changes
+
+## Decisions
+
+1. **CloudFront construct**: Migrate to new `Distribution` API with Origin Access Control (OAC) -- decided yes
+2. **`aws-cdk-lib` version pin**: Pin to `^2.248.0` (latest as of 2026-04-12) -- decided yes

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,844 +2,31 @@
 # yarn lockfile v1
 
 
-"@aws-cdk/assert@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/assert/-/assert-1.138.0.tgz#fffd44fda4d9e52341d5d22a50d25ab7f71d9bed"
-  integrity sha512-1h7ZZj7KEJWzmmuoa4OFIoyvI8rYK3pQqYiUeCoHoBbyXmvgEZcjiL7h7TAcGTbGFmLUZRyDuqCuC/aPOBgwGg==
-  dependencies:
-    "@aws-cdk/cloudformation-diff" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    "@aws-cdk/cx-api" "1.138.0"
-    constructs "^3.3.69"
+"@aws-cdk/asset-awscli-v1@2.2.273":
+  version "2.2.273"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.273.tgz#81efd05df3f44c5e604f1d43c4b48e12874b0bd3"
+  integrity sha512-X57HYUtHt9BQrlrzUNcMyRsDUCoakYNnY6qh5lNwRCHPtQoTfXmuISkfLk0AjLkcbS5lw1LLTQFiQhTDXfiTvg==
 
-"@aws-cdk/assets@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/assets/-/assets-1.138.0.tgz#156397a63c790039f6fda8db43ce5dad3eea889f"
-  integrity sha512-DKaFo5yrbjyn2KyTWwNlwMtQLefR068dKzNLqwwll1+rNGNbPj3aveBVyRSlp1J98zCqQdA7KdsasTtbgo72mw==
-  dependencies:
-    "@aws-cdk/core" "1.138.0"
-    "@aws-cdk/cx-api" "1.138.0"
-    constructs "^3.3.69"
+"@aws-cdk/asset-node-proxy-agent-v6@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.1.tgz#184f980024d67ad60bdc52ab88c59c73fa070346"
+  integrity sha512-We4bmHaowOPHr+IQR4/FyTGjRfjgBj4ICMjtqmJeBDWad3Q/6St12NT07leNtyuukv2qMhtSZJQorD8KpKTwRA==
 
-"@aws-cdk/aws-acmpca@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-acmpca/-/aws-acmpca-1.138.0.tgz#30f00775cf8542c1641ed5fd58bd7b6ec026d9db"
-  integrity sha512-ugHxkPRm1y6CIA1LbgywEOI99rapV94fnIV4L9KGPQ8cKRXbCDf2wgGXUbNgAhdydy96fzylIb+Td2H19zk9cA==
+"@aws-cdk/cloud-assembly-api@^2.2.0":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cloud-assembly-api/-/cloud-assembly-api-2.2.1.tgz#43884b6637c002731115ff922bd256dd8b231ef5"
+  integrity sha512-24ARpDQzF39UTickUgDH6RIs5otPG4aaKJZ93XUSNwiPSR9T+h7gXSF982+NZVYK+7SetQaqrVbm4lcF6dmXWw==
   dependencies:
-    "@aws-cdk/core" "1.138.0"
-    constructs "^3.3.69"
+    jsonschema "~1.4.1"
+    semver "^7.7.4"
 
-"@aws-cdk/aws-apigateway@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-apigateway/-/aws-apigateway-1.138.0.tgz#121ae5396304b106fbcc7f071801497176b7b429"
-  integrity sha512-qDKX8OwYC5ErC3HZF2e1gFDvhj9B/UXVWI1z6wmNnjwIdohZK5tkbjEzq3vY8K7zStK6jsADwhNaHw0k4x83rg==
+"@aws-cdk/cloud-assembly-schema@^53.0.0":
+  version "53.14.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.14.0.tgz#aed5fed83657ed904937296616ae2a5f2c109f21"
+  integrity sha512-prx2sbFfKrVf3NNXMOmWq6lsIBeWQDIqMTILLAddGiidn9j7OnLUubknWpJlLozMveTvQELdI++nUwq6jwCm9g==
   dependencies:
-    "@aws-cdk/aws-certificatemanager" "1.138.0"
-    "@aws-cdk/aws-cloudwatch" "1.138.0"
-    "@aws-cdk/aws-cognito" "1.138.0"
-    "@aws-cdk/aws-ec2" "1.138.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.138.0"
-    "@aws-cdk/aws-iam" "1.138.0"
-    "@aws-cdk/aws-lambda" "1.138.0"
-    "@aws-cdk/aws-logs" "1.138.0"
-    "@aws-cdk/aws-s3" "1.138.0"
-    "@aws-cdk/aws-s3-assets" "1.138.0"
-    "@aws-cdk/aws-stepfunctions" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    "@aws-cdk/cx-api" "1.138.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-apigatewayv2-integrations@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-apigatewayv2-integrations/-/aws-apigatewayv2-integrations-1.138.0.tgz#0ff688ba0300327d8a6ca09e286791cc72de6a5d"
-  integrity sha512-IOM2QlKYe31SJpslQYfz6i9Aw7DTCUZWShYEokOO1tictgHiqZIq73Y6Svh2Ml2Nrax+kxyM0xd1hPUe6iYeXQ==
-  dependencies:
-    "@aws-cdk/aws-apigatewayv2" "1.138.0"
-    "@aws-cdk/aws-ec2" "1.138.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.138.0"
-    "@aws-cdk/aws-iam" "1.138.0"
-    "@aws-cdk/aws-lambda" "1.138.0"
-    "@aws-cdk/aws-servicediscovery" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-apigatewayv2@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-apigatewayv2/-/aws-apigatewayv2-1.138.0.tgz#52381a5e5493e889805ebff03f41fc62d6bbb1a2"
-  integrity sha512-ZIwikKIKSx8RiZhF+ry12vE/yG/xonmiFJu7wS8fFrO6WSk4/P/ozzCB9i7y7OLliOnfLaqEUx6Pkm0VXUc6Rw==
-  dependencies:
-    "@aws-cdk/aws-certificatemanager" "1.138.0"
-    "@aws-cdk/aws-cloudwatch" "1.138.0"
-    "@aws-cdk/aws-ec2" "1.138.0"
-    "@aws-cdk/aws-iam" "1.138.0"
-    "@aws-cdk/aws-s3" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-applicationautoscaling@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-1.138.0.tgz#f7cf866707108f1d544910f5a79b21f88274b1d8"
-  integrity sha512-vCTzyqsTMeq0CmhotIxpyv3pdo722pFi55UCrzKdRfd2jMv1P5P6fIbCxD9Fi2aXtfdIzUmLjUBeGSYD8c6erA==
-  dependencies:
-    "@aws-cdk/aws-autoscaling-common" "1.138.0"
-    "@aws-cdk/aws-cloudwatch" "1.138.0"
-    "@aws-cdk/aws-iam" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-autoscaling-common@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling-common/-/aws-autoscaling-common-1.138.0.tgz#a3c23770426711f467c75a07a3525bcafc934442"
-  integrity sha512-BPrqU9jRdbJvotZ3tNY1HclKQuAaMH53by8fWLVlEBN/nQxu4h0jGsfaDSmLkr7dhdIw43YlofQOUFPZPo/M4Q==
-  dependencies:
-    "@aws-cdk/aws-iam" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-autoscaling-hooktargets@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling-hooktargets/-/aws-autoscaling-hooktargets-1.138.0.tgz#667378472b995f52c7f15ae26eef4ed038e76786"
-  integrity sha512-qwzf2TmDbIToz2t0H10SpgNsvLI1IJV/LRBkRi7r+WeMAxzPMHoEjM5EdgDCwzyA/UYtgwAJTj9luYVf6SG5VQ==
-  dependencies:
-    "@aws-cdk/aws-autoscaling" "1.138.0"
-    "@aws-cdk/aws-iam" "1.138.0"
-    "@aws-cdk/aws-kms" "1.138.0"
-    "@aws-cdk/aws-lambda" "1.138.0"
-    "@aws-cdk/aws-sns" "1.138.0"
-    "@aws-cdk/aws-sns-subscriptions" "1.138.0"
-    "@aws-cdk/aws-sqs" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-autoscaling@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling/-/aws-autoscaling-1.138.0.tgz#457727be60700f484bf907ef45594a1b60193329"
-  integrity sha512-ZqgKOL9IQbMvfqrtIF646Uc0aR1eFOsIb8DpaC3zVotrmi72UiT6fr98oD04eElRl10IsQyyNQd7sr7x6orkwQ==
-  dependencies:
-    "@aws-cdk/aws-autoscaling-common" "1.138.0"
-    "@aws-cdk/aws-cloudwatch" "1.138.0"
-    "@aws-cdk/aws-ec2" "1.138.0"
-    "@aws-cdk/aws-elasticloadbalancing" "1.138.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.138.0"
-    "@aws-cdk/aws-iam" "1.138.0"
-    "@aws-cdk/aws-sns" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-certificatemanager@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-certificatemanager/-/aws-certificatemanager-1.138.0.tgz#9b6d6bc5341a6bb42a59af60083e61974ea1c34e"
-  integrity sha512-jUS02oc69npDgnHQoxXe9lnovdv4j+J5KZ86SGNb3P5z5gU8/ZKFI0VHYjHjPlMajarJCP1M4n/8ty7AAPK7eA==
-  dependencies:
-    "@aws-cdk/aws-acmpca" "1.138.0"
-    "@aws-cdk/aws-cloudwatch" "1.138.0"
-    "@aws-cdk/aws-iam" "1.138.0"
-    "@aws-cdk/aws-lambda" "1.138.0"
-    "@aws-cdk/aws-route53" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-cloudformation@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.138.0.tgz#94dcfef7730fb1bb7532ec788deff56954bd27b7"
-  integrity sha512-tOL1izAmciq1Uo18a43XSARbj5QQSaDBBbW3DNqE+S7k+SkEgM5rXIToD8KcE16g+sQ31gYfjxSPT/8qPH0N3w==
-  dependencies:
-    "@aws-cdk/aws-iam" "1.138.0"
-    "@aws-cdk/aws-lambda" "1.138.0"
-    "@aws-cdk/aws-s3" "1.138.0"
-    "@aws-cdk/aws-sns" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    "@aws-cdk/cx-api" "1.138.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-cloudfront@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudfront/-/aws-cloudfront-1.138.0.tgz#52f9daf40e19dfd72a84d33400a4294ae2da2ba5"
-  integrity sha512-cid4eeHdBpenQe1aB91HXKh3Qsk7/ExtbLjAImBgHJ0tcFKE71ecdFhh+rOezFrZwVUWqxbJgi5YU2D1GDZSRA==
-  dependencies:
-    "@aws-cdk/aws-certificatemanager" "1.138.0"
-    "@aws-cdk/aws-cloudwatch" "1.138.0"
-    "@aws-cdk/aws-ec2" "1.138.0"
-    "@aws-cdk/aws-iam" "1.138.0"
-    "@aws-cdk/aws-kms" "1.138.0"
-    "@aws-cdk/aws-lambda" "1.138.0"
-    "@aws-cdk/aws-s3" "1.138.0"
-    "@aws-cdk/aws-ssm" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    "@aws-cdk/cx-api" "1.138.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-cloudwatch@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.138.0.tgz#82efd86bb2640c96f82e0b635a9d6d8a48b661b2"
-  integrity sha512-Dsw4YmoFfJLJUBOv9ifbfsG7K4xVj8XmUZnon0Ci2ydBv0iX26ygA76kXaqA+psLGkfoQxFRaVrDYrs6IKZ4Vw==
-  dependencies:
-    "@aws-cdk/aws-iam" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-codebuild@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codebuild/-/aws-codebuild-1.138.0.tgz#404f6d22980794e25f7cad1d7bdfdb9fe3322fd3"
-  integrity sha512-ZbHpTfikNvSZEHYhwn6AhgbTWqDA/h+Q55FmqUCqF7eI6RdrNj82VpVpOYQakx/l2IpxjvbW1CazQTyekfdI8A==
-  dependencies:
-    "@aws-cdk/assets" "1.138.0"
-    "@aws-cdk/aws-cloudwatch" "1.138.0"
-    "@aws-cdk/aws-codecommit" "1.138.0"
-    "@aws-cdk/aws-codestarnotifications" "1.138.0"
-    "@aws-cdk/aws-ec2" "1.138.0"
-    "@aws-cdk/aws-ecr" "1.138.0"
-    "@aws-cdk/aws-ecr-assets" "1.138.0"
-    "@aws-cdk/aws-events" "1.138.0"
-    "@aws-cdk/aws-iam" "1.138.0"
-    "@aws-cdk/aws-kms" "1.138.0"
-    "@aws-cdk/aws-logs" "1.138.0"
-    "@aws-cdk/aws-s3" "1.138.0"
-    "@aws-cdk/aws-s3-assets" "1.138.0"
-    "@aws-cdk/aws-secretsmanager" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    "@aws-cdk/region-info" "1.138.0"
-    constructs "^3.3.69"
-    yaml "1.10.2"
-
-"@aws-cdk/aws-codecommit@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codecommit/-/aws-codecommit-1.138.0.tgz#887092319f9e19ab4342d87e489f710d0478e283"
-  integrity sha512-vxrr6MOAmVViA1J5UpK68iihQW6SiYlw5yyqGFpojS2Stqs/gkeGjuxFOaeqi3FujL3ryOu+ZBbVelNFXfILEw==
-  dependencies:
-    "@aws-cdk/aws-codestarnotifications" "1.138.0"
-    "@aws-cdk/aws-events" "1.138.0"
-    "@aws-cdk/aws-iam" "1.138.0"
-    "@aws-cdk/aws-s3-assets" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-codedeploy@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codedeploy/-/aws-codedeploy-1.138.0.tgz#1efc3ae0434bee60f33094467a89fec2b660a7e6"
-  integrity sha512-KAPDlaUPhhaSsDKW/MIryetPvvIsCtPHHgUAL9cnPr2OJBkRK/pHzr+e8xvrcEcRZ1t8KvJKenMessjGjrPDKg==
-  dependencies:
-    "@aws-cdk/aws-autoscaling" "1.138.0"
-    "@aws-cdk/aws-cloudwatch" "1.138.0"
-    "@aws-cdk/aws-ec2" "1.138.0"
-    "@aws-cdk/aws-elasticloadbalancing" "1.138.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.138.0"
-    "@aws-cdk/aws-iam" "1.138.0"
-    "@aws-cdk/aws-lambda" "1.138.0"
-    "@aws-cdk/aws-s3" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    "@aws-cdk/custom-resources" "1.138.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-codeguruprofiler@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codeguruprofiler/-/aws-codeguruprofiler-1.138.0.tgz#4ba5356f283f981e59e9c16ab5b16386a0bbbf66"
-  integrity sha512-xxgKmdP+8pKMMURsaszBdh6gkzGHqdSxj5Z+B/3CpZSYMvypPXXLq96C2zIzoed7gSP3rgf9zV9YWXXTZY3gYA==
-  dependencies:
-    "@aws-cdk/aws-iam" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-codepipeline-actions@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codepipeline-actions/-/aws-codepipeline-actions-1.138.0.tgz#6c4679f40474391bb889f4628f4a27da7880c3ef"
-  integrity sha512-CBsAm/7LHiqIv/o0PsOzJaUPo4kUQ1Z618nFAuUbgfSyZHRt5EW5KrOpmG2TDE0t2lCoh3aI9D90af+tKZMR0g==
-  dependencies:
-    "@aws-cdk/aws-cloudformation" "1.138.0"
-    "@aws-cdk/aws-codebuild" "1.138.0"
-    "@aws-cdk/aws-codecommit" "1.138.0"
-    "@aws-cdk/aws-codedeploy" "1.138.0"
-    "@aws-cdk/aws-codepipeline" "1.138.0"
-    "@aws-cdk/aws-ec2" "1.138.0"
-    "@aws-cdk/aws-ecr" "1.138.0"
-    "@aws-cdk/aws-ecs" "1.138.0"
-    "@aws-cdk/aws-events" "1.138.0"
-    "@aws-cdk/aws-events-targets" "1.138.0"
-    "@aws-cdk/aws-iam" "1.138.0"
-    "@aws-cdk/aws-kms" "1.138.0"
-    "@aws-cdk/aws-lambda" "1.138.0"
-    "@aws-cdk/aws-s3" "1.138.0"
-    "@aws-cdk/aws-sns" "1.138.0"
-    "@aws-cdk/aws-sns-subscriptions" "1.138.0"
-    "@aws-cdk/aws-stepfunctions" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    case "1.6.3"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-codepipeline@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codepipeline/-/aws-codepipeline-1.138.0.tgz#9dd951d12c587cbdedeac92a1a920b0f7d19638a"
-  integrity sha512-MNvrc91y03Dl8BoXBKgAvqg5GJpq8u1THY747SsoMBbjTaYrmmUjq6aFqqf/VCXVSQIJWfqCYMmNk+pQIehkjw==
-  dependencies:
-    "@aws-cdk/aws-codestarnotifications" "1.138.0"
-    "@aws-cdk/aws-events" "1.138.0"
-    "@aws-cdk/aws-iam" "1.138.0"
-    "@aws-cdk/aws-kms" "1.138.0"
-    "@aws-cdk/aws-s3" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-codestarnotifications@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codestarnotifications/-/aws-codestarnotifications-1.138.0.tgz#26da52d4c48a1b68ee6c68f8ea036c1419cfa5f0"
-  integrity sha512-LFBYencxDdpvQciTF9v4urw5GbS7tuVhyUFvllc3f46LWcaPG6yDKNZS5Q/GqtYGrWzVXveFElZf9ca6Ta9bwQ==
-  dependencies:
-    "@aws-cdk/core" "1.138.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-cognito@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cognito/-/aws-cognito-1.138.0.tgz#25e7cfe731359663c512c83dfbbbde9442c06a3b"
-  integrity sha512-ZRbPFGyeWfqL13zEGqh12Vh2pG4X5iteipKuTC0n96idJVCGXgxMN58h7FnsIMWncvaRlwtevXGoYAv5M+Et7w==
-  dependencies:
-    "@aws-cdk/aws-certificatemanager" "1.138.0"
-    "@aws-cdk/aws-iam" "1.138.0"
-    "@aws-cdk/aws-kms" "1.138.0"
-    "@aws-cdk/aws-lambda" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    "@aws-cdk/custom-resources" "1.138.0"
-    constructs "^3.3.69"
-    punycode "^2.1.1"
-
-"@aws-cdk/aws-dynamodb@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-dynamodb/-/aws-dynamodb-1.138.0.tgz#88a834fbe2a5f6f30eaabbe7062400662979d0cb"
-  integrity sha512-Iss82XvSJEOHjl9snGAJ2wzUkJZ7P3O6M2fEBVJ0ZcjQMFhYwhDquq6BRzvq6Cs66TUfcgpPPVVAPYMjYwrjKg==
-  dependencies:
-    "@aws-cdk/aws-applicationautoscaling" "1.138.0"
-    "@aws-cdk/aws-cloudwatch" "1.138.0"
-    "@aws-cdk/aws-iam" "1.138.0"
-    "@aws-cdk/aws-kinesis" "1.138.0"
-    "@aws-cdk/aws-kms" "1.138.0"
-    "@aws-cdk/aws-lambda" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    "@aws-cdk/custom-resources" "1.138.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-ec2@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ec2/-/aws-ec2-1.138.0.tgz#9ce0ce1bd162e9f6717a2b9018d2addd0e7af28e"
-  integrity sha512-tpnt746IQ1NBgomIQQrCLMP04a4pUJs3Mb8QlrecT31FvEulDu6LHFTC8r9M+Jam3x7E0BybjNosFNgk/ovayw==
-  dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.138.0"
-    "@aws-cdk/aws-iam" "1.138.0"
-    "@aws-cdk/aws-kms" "1.138.0"
-    "@aws-cdk/aws-logs" "1.138.0"
-    "@aws-cdk/aws-s3" "1.138.0"
-    "@aws-cdk/aws-s3-assets" "1.138.0"
-    "@aws-cdk/aws-ssm" "1.138.0"
-    "@aws-cdk/cloud-assembly-schema" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    "@aws-cdk/cx-api" "1.138.0"
-    "@aws-cdk/region-info" "1.138.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-ecr-assets@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ecr-assets/-/aws-ecr-assets-1.138.0.tgz#88c4a312715c720c66949c7b0cfd6f2b1bc8a5fd"
-  integrity sha512-QRcVN96XS4sB4R1nY9FeP7l3/ch7HA5bgVKsLn9f5JKnC+NDlO6yRWORD0UKmcbCO9uzQiHh8D8CcboUqRWgfw==
-  dependencies:
-    "@aws-cdk/assets" "1.138.0"
-    "@aws-cdk/aws-ecr" "1.138.0"
-    "@aws-cdk/aws-iam" "1.138.0"
-    "@aws-cdk/aws-s3" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    "@aws-cdk/cx-api" "1.138.0"
-    constructs "^3.3.69"
-    minimatch "^3.0.4"
-
-"@aws-cdk/aws-ecr@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ecr/-/aws-ecr-1.138.0.tgz#1caf759267ccc0a56ca243899fc17b6373c473a5"
-  integrity sha512-yD+rYPzmR24din0MSsKqTVUmG/KgTDOrI0pY4e960hdI7gSOz+AGd20SSiJ6if21RsTRaOTCcDA9xg9ZcSj55g==
-  dependencies:
-    "@aws-cdk/aws-events" "1.138.0"
-    "@aws-cdk/aws-iam" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-ecs@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ecs/-/aws-ecs-1.138.0.tgz#c9a757e0dfc617ebf35b4a0b16c7034bf659531b"
-  integrity sha512-ItAEsbpyOqbCBRDVtz24JSPIcOl57wcdM7tBd3or41N39mKAxBOb8o1O3ueX6gU0thGR37uYGLLNVrtMZvGTbQ==
-  dependencies:
-    "@aws-cdk/aws-applicationautoscaling" "1.138.0"
-    "@aws-cdk/aws-autoscaling" "1.138.0"
-    "@aws-cdk/aws-autoscaling-hooktargets" "1.138.0"
-    "@aws-cdk/aws-certificatemanager" "1.138.0"
-    "@aws-cdk/aws-cloudwatch" "1.138.0"
-    "@aws-cdk/aws-ec2" "1.138.0"
-    "@aws-cdk/aws-ecr" "1.138.0"
-    "@aws-cdk/aws-ecr-assets" "1.138.0"
-    "@aws-cdk/aws-elasticloadbalancing" "1.138.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.138.0"
-    "@aws-cdk/aws-iam" "1.138.0"
-    "@aws-cdk/aws-kms" "1.138.0"
-    "@aws-cdk/aws-lambda" "1.138.0"
-    "@aws-cdk/aws-logs" "1.138.0"
-    "@aws-cdk/aws-route53" "1.138.0"
-    "@aws-cdk/aws-route53-targets" "1.138.0"
-    "@aws-cdk/aws-s3" "1.138.0"
-    "@aws-cdk/aws-s3-assets" "1.138.0"
-    "@aws-cdk/aws-secretsmanager" "1.138.0"
-    "@aws-cdk/aws-servicediscovery" "1.138.0"
-    "@aws-cdk/aws-sns" "1.138.0"
-    "@aws-cdk/aws-sqs" "1.138.0"
-    "@aws-cdk/aws-ssm" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    "@aws-cdk/cx-api" "1.138.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-efs@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-efs/-/aws-efs-1.138.0.tgz#5b8746283811549af331ec0fe1021f5e6d718578"
-  integrity sha512-XBRR5OvQ0ZxCsam3ZD0ocjwx7NhIpfI3JiucCmGOnsTQf2+AlU6FbxO8kO9/zTyFUBjeAgdE0cYQ3SD6q2b1tQ==
-  dependencies:
-    "@aws-cdk/aws-ec2" "1.138.0"
-    "@aws-cdk/aws-iam" "1.138.0"
-    "@aws-cdk/aws-kms" "1.138.0"
-    "@aws-cdk/cloud-assembly-schema" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    "@aws-cdk/cx-api" "1.138.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-elasticloadbalancing@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-elasticloadbalancing/-/aws-elasticloadbalancing-1.138.0.tgz#6d317cf48bc13cdbd7003708742c7ef56f4d5e2b"
-  integrity sha512-5KGjeH0YIqbz/22WwLUNvNVHj8Z7w+a4h65iKQhItTJ39kYDpOiSPEsej0MNVK/xBpVCZB5YTYRxVFpxR/fhHA==
-  dependencies:
-    "@aws-cdk/aws-ec2" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-elasticloadbalancingv2@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-elasticloadbalancingv2/-/aws-elasticloadbalancingv2-1.138.0.tgz#861bf3ac8b86ac8c46fdc14f7d6f6627d2c5de14"
-  integrity sha512-88VM/Q+kFkYPJ7wijrxjVbdGPFxS5j014fVJOhmHaclqCWxdXK9X+20SYrnEV7GZTq0tIAyerwO8+TU2QP7nyg==
-  dependencies:
-    "@aws-cdk/aws-certificatemanager" "1.138.0"
-    "@aws-cdk/aws-cloudwatch" "1.138.0"
-    "@aws-cdk/aws-ec2" "1.138.0"
-    "@aws-cdk/aws-iam" "1.138.0"
-    "@aws-cdk/aws-lambda" "1.138.0"
-    "@aws-cdk/aws-s3" "1.138.0"
-    "@aws-cdk/cloud-assembly-schema" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    "@aws-cdk/cx-api" "1.138.0"
-    "@aws-cdk/region-info" "1.138.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-events-targets@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-events-targets/-/aws-events-targets-1.138.0.tgz#75d91f18ac23f1055f4cb8ced8677cd007b6405a"
-  integrity sha512-gywnFeZdHJVPOnavQQleKiYn8qjDoI0J1PgcGGZDqQnd2vmMAJbl+HynvylymoqltCJBabWZNxa8vYepwj0aag==
-  dependencies:
-    "@aws-cdk/aws-apigateway" "1.138.0"
-    "@aws-cdk/aws-autoscaling" "1.138.0"
-    "@aws-cdk/aws-codebuild" "1.138.0"
-    "@aws-cdk/aws-codepipeline" "1.138.0"
-    "@aws-cdk/aws-ec2" "1.138.0"
-    "@aws-cdk/aws-ecs" "1.138.0"
-    "@aws-cdk/aws-events" "1.138.0"
-    "@aws-cdk/aws-iam" "1.138.0"
-    "@aws-cdk/aws-kinesis" "1.138.0"
-    "@aws-cdk/aws-kinesisfirehose" "1.138.0"
-    "@aws-cdk/aws-kms" "1.138.0"
-    "@aws-cdk/aws-lambda" "1.138.0"
-    "@aws-cdk/aws-logs" "1.138.0"
-    "@aws-cdk/aws-sns" "1.138.0"
-    "@aws-cdk/aws-sns-subscriptions" "1.138.0"
-    "@aws-cdk/aws-sqs" "1.138.0"
-    "@aws-cdk/aws-stepfunctions" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    "@aws-cdk/custom-resources" "1.138.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-events@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-events/-/aws-events-1.138.0.tgz#8dca8c247c6c8b231414b6e0609535701326b1bd"
-  integrity sha512-33IOAaN99rmUj283b8puW9DK/iqCZyAbvcc32e/59oxZmANMYmYSHLjQJzsTQJgXXFX3nYCB8T+j69vIMeMd/g==
-  dependencies:
-    "@aws-cdk/aws-iam" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-globalaccelerator@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-globalaccelerator/-/aws-globalaccelerator-1.138.0.tgz#373f5393e0eaf56eb45186deff34f08d58a51034"
-  integrity sha512-2O+A9yduSv45w1xbluht1PCT/GuDvo1Z+sIel0C6qnwChCcEpBNVUo9ZmKJq7vkX+xoolGfDBsDY1tFCuDqGbg==
-  dependencies:
-    "@aws-cdk/aws-ec2" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    "@aws-cdk/custom-resources" "1.138.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-iam@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-iam/-/aws-iam-1.138.0.tgz#c3eaf1cd05419adf9c7959c99a4f7377eedb9eac"
-  integrity sha512-/SLIznFUWxkV19QhwFK+lVTlxTtgHHtx45a+na1oduNP8KOUhq6Q+p699Kfs/l/BjDrNYw5w57Qdftb5P2NXsg==
-  dependencies:
-    "@aws-cdk/core" "1.138.0"
-    "@aws-cdk/region-info" "1.138.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-kinesis@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kinesis/-/aws-kinesis-1.138.0.tgz#83c42e8c75c223d7e612650d9da1aaad51edbd6b"
-  integrity sha512-iEBR93GhOQsjteQhQ3egav3XELtt+57H1vvrQq/7xDGn51rvO8FwwdM+B+pcZmWFnQ4Tka3uwSVbsTFFDfR48w==
-  dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.138.0"
-    "@aws-cdk/aws-iam" "1.138.0"
-    "@aws-cdk/aws-kms" "1.138.0"
-    "@aws-cdk/aws-logs" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-kinesisfirehose@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kinesisfirehose/-/aws-kinesisfirehose-1.138.0.tgz#53a0db8bd3622618206a70ab2391660a6f14450f"
-  integrity sha512-CBBrpqYZ30ct/x8WJtCadKf463pZOp9CvNesRgVpX0bZCeF1w+G6eeAA7FCnVxx483bCW9enSZt/vCH9vdZsaQ==
-  dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.138.0"
-    "@aws-cdk/aws-ec2" "1.138.0"
-    "@aws-cdk/aws-iam" "1.138.0"
-    "@aws-cdk/aws-kinesis" "1.138.0"
-    "@aws-cdk/aws-kms" "1.138.0"
-    "@aws-cdk/aws-lambda" "1.138.0"
-    "@aws-cdk/aws-logs" "1.138.0"
-    "@aws-cdk/aws-s3" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    "@aws-cdk/region-info" "1.138.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-kms@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kms/-/aws-kms-1.138.0.tgz#2a5657d885a4e6413524eb36dfdfbe6af5533ec0"
-  integrity sha512-CTUUt9D9H4stkTHu+KW36+yVlmbEDYoJ5imUkmRFUuN9jLTa260off/wOgWOeepNRyAvdCJXCOx3x8FYQ8jjEA==
-  dependencies:
-    "@aws-cdk/aws-iam" "1.138.0"
-    "@aws-cdk/cloud-assembly-schema" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    "@aws-cdk/cx-api" "1.138.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-lambda@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda/-/aws-lambda-1.138.0.tgz#cab8587c534cade98025fe05679bf3435639ce70"
-  integrity sha512-1s7BWntqiZDsWScgSGdRNXul2vNmFDdAUQKeuHKdr/+BvRJWIPmpQVhNbyDJg4qcSDZRrOPLmH6XC+tMjMEnCQ==
-  dependencies:
-    "@aws-cdk/aws-applicationautoscaling" "1.138.0"
-    "@aws-cdk/aws-cloudwatch" "1.138.0"
-    "@aws-cdk/aws-codeguruprofiler" "1.138.0"
-    "@aws-cdk/aws-ec2" "1.138.0"
-    "@aws-cdk/aws-ecr" "1.138.0"
-    "@aws-cdk/aws-ecr-assets" "1.138.0"
-    "@aws-cdk/aws-efs" "1.138.0"
-    "@aws-cdk/aws-events" "1.138.0"
-    "@aws-cdk/aws-iam" "1.138.0"
-    "@aws-cdk/aws-kms" "1.138.0"
-    "@aws-cdk/aws-logs" "1.138.0"
-    "@aws-cdk/aws-s3" "1.138.0"
-    "@aws-cdk/aws-s3-assets" "1.138.0"
-    "@aws-cdk/aws-signer" "1.138.0"
-    "@aws-cdk/aws-sqs" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    "@aws-cdk/cx-api" "1.138.0"
-    "@aws-cdk/region-info" "1.138.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-logs@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-logs/-/aws-logs-1.138.0.tgz#641617dec0276bdf04c19a3805800d631b3600f3"
-  integrity sha512-uFVb75hcDWn86EBVf9SKaBo0wQv4OpLOdnO9og+aVfXSTOsCC9i5zaVNBMBoh9yJ3gqWIyTAILkxWqJazlxJEQ==
-  dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.138.0"
-    "@aws-cdk/aws-iam" "1.138.0"
-    "@aws-cdk/aws-kms" "1.138.0"
-    "@aws-cdk/aws-s3-assets" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    "@aws-cdk/cx-api" "1.138.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-route53-targets@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-route53-targets/-/aws-route53-targets-1.138.0.tgz#22a0207aa0d384b0d51450329a99f0095f175a76"
-  integrity sha512-gyrLTD1NGeyILE2ZEISMVtuj4DMl+7JuJEKXjfrabAxWVyeWKIADGKnBjVMoyeqnmR0xXxUpX1bnXrM1BbsCaA==
-  dependencies:
-    "@aws-cdk/aws-apigateway" "1.138.0"
-    "@aws-cdk/aws-cloudfront" "1.138.0"
-    "@aws-cdk/aws-cognito" "1.138.0"
-    "@aws-cdk/aws-ec2" "1.138.0"
-    "@aws-cdk/aws-elasticloadbalancing" "1.138.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.138.0"
-    "@aws-cdk/aws-globalaccelerator" "1.138.0"
-    "@aws-cdk/aws-iam" "1.138.0"
-    "@aws-cdk/aws-route53" "1.138.0"
-    "@aws-cdk/aws-s3" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    "@aws-cdk/region-info" "1.138.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-route53@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-route53/-/aws-route53-1.138.0.tgz#18a72e85affc5a3eadbaa53e7f1bb43b74bdbafa"
-  integrity sha512-GFwcXNfEUV/yJaJwpCd2GT8OLU1QR3F3XaGDMPg3fMdKZlpXwNIwHxJ2clFgQGNmR3yOt9xuHE6CqCbcwiPQoQ==
-  dependencies:
-    "@aws-cdk/aws-ec2" "1.138.0"
-    "@aws-cdk/aws-iam" "1.138.0"
-    "@aws-cdk/aws-logs" "1.138.0"
-    "@aws-cdk/cloud-assembly-schema" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    "@aws-cdk/custom-resources" "1.138.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-s3-assets@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.138.0.tgz#a09b40f42d05a360ef18d3b801b263241d6838af"
-  integrity sha512-L9HX9ZaECJpzu8+QkUyoSrIJUwsNv/bcrbRNbexfdnm0+dPTIp5N107t4zn9xXHNaUgoJZY4e7aih+Wx1hjbSQ==
-  dependencies:
-    "@aws-cdk/assets" "1.138.0"
-    "@aws-cdk/aws-iam" "1.138.0"
-    "@aws-cdk/aws-kms" "1.138.0"
-    "@aws-cdk/aws-s3" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    "@aws-cdk/cx-api" "1.138.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-s3-deployment@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3-deployment/-/aws-s3-deployment-1.138.0.tgz#6639091915e96e1d300c2251a09c85b05caaabf9"
-  integrity sha512-30q4Qv2/e6COv+qFmWZf+cl2SqaT2bq4SSKJ8xGcQIppgB1wA0YQ2i2GEU3GODPiPuNozJSyeqXT2k+6RNImcA==
-  dependencies:
-    "@aws-cdk/aws-cloudfront" "1.138.0"
-    "@aws-cdk/aws-ec2" "1.138.0"
-    "@aws-cdk/aws-efs" "1.138.0"
-    "@aws-cdk/aws-iam" "1.138.0"
-    "@aws-cdk/aws-lambda" "1.138.0"
-    "@aws-cdk/aws-logs" "1.138.0"
-    "@aws-cdk/aws-s3" "1.138.0"
-    "@aws-cdk/aws-s3-assets" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    "@aws-cdk/lambda-layer-awscli" "1.138.0"
-    case "1.6.3"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-s3@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3/-/aws-s3-1.138.0.tgz#0899a832136d1ce228e476ab192fd40d8c329766"
-  integrity sha512-D9yF7HXGlXih4AerZSQKTYF4hOHq+DgbZHYdhyWPCX91ShytZK9p4B3yZ44JbydXahloK7Cos2CLpk8995PCVw==
-  dependencies:
-    "@aws-cdk/aws-events" "1.138.0"
-    "@aws-cdk/aws-iam" "1.138.0"
-    "@aws-cdk/aws-kms" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    "@aws-cdk/cx-api" "1.138.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-sam@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sam/-/aws-sam-1.138.0.tgz#32e0efb8697208c8f27e2baa100ece55da8b1929"
-  integrity sha512-ZnVRQ4yCnCovqNumH0bavwBxOO+Y3CeZ5bqCO3V9ALkyh0OT6cfb01PEvGlPQCuU/+gDPGaerdiJ8+uZU8dNdg==
-  dependencies:
-    "@aws-cdk/core" "1.138.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-secretsmanager@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-secretsmanager/-/aws-secretsmanager-1.138.0.tgz#9086696df1af010e749283849c2332e41ce4f306"
-  integrity sha512-P8tLzZQBfCoscSpX5E0EaNqRNQLWcnho2fa7Y7sQ6FkDk/hPI8oEf6g0J/r5tCuSyeDUncgSDKO1VWyLR789ug==
-  dependencies:
-    "@aws-cdk/aws-ec2" "1.138.0"
-    "@aws-cdk/aws-iam" "1.138.0"
-    "@aws-cdk/aws-kms" "1.138.0"
-    "@aws-cdk/aws-lambda" "1.138.0"
-    "@aws-cdk/aws-sam" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    "@aws-cdk/cx-api" "1.138.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-servicediscovery@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-servicediscovery/-/aws-servicediscovery-1.138.0.tgz#450da9a17aec41de286ae1f9c5025c5dc9bcd0c3"
-  integrity sha512-khbGQuyr1J/+4ENA+stv7yO/SX2wGv0Kq+RQ+CkpiuZ1QPbSxqTqeiOymL7Tzghvl9qqR10B+p7x4Arr23HC8Q==
-  dependencies:
-    "@aws-cdk/aws-ec2" "1.138.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.138.0"
-    "@aws-cdk/aws-route53" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-signer@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-signer/-/aws-signer-1.138.0.tgz#12bd2501473ec4c140a502d2c76823ce64160a8b"
-  integrity sha512-Cb8ESepAp4mMu8Lg/UOKh6hpQx2IFchvrXeCMIwBCrF1899I59if4/nzvcrK8jLTOVOGU0GDvGAmpjDoydRtig==
-  dependencies:
-    "@aws-cdk/core" "1.138.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-sns-subscriptions@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sns-subscriptions/-/aws-sns-subscriptions-1.138.0.tgz#9dfd7edec351e2f422f86e936ee4e1383c8c938d"
-  integrity sha512-vS/mSpkIOdw4zYtMZ+VJaarA+FN1GG7X0Pqmd+NXaBKlwrVqsWrSLKyj6lrx25DFvz49DlFqJgDWLxLM+5L9ow==
-  dependencies:
-    "@aws-cdk/aws-iam" "1.138.0"
-    "@aws-cdk/aws-kms" "1.138.0"
-    "@aws-cdk/aws-lambda" "1.138.0"
-    "@aws-cdk/aws-sns" "1.138.0"
-    "@aws-cdk/aws-sqs" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-sns@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sns/-/aws-sns-1.138.0.tgz#e29a80f88a991db5ae7433b9f2f2d674ddaaf12e"
-  integrity sha512-AY4n/pF/TVpfMnv/spl4yJUXf6zNYNoZ6bf5Uz4rLDe11/mHlPWAvlUeFUlcfGJ2tPfKfnOI0md6OndxXfQycw==
-  dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.138.0"
-    "@aws-cdk/aws-codestarnotifications" "1.138.0"
-    "@aws-cdk/aws-events" "1.138.0"
-    "@aws-cdk/aws-iam" "1.138.0"
-    "@aws-cdk/aws-kms" "1.138.0"
-    "@aws-cdk/aws-sqs" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-sqs@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sqs/-/aws-sqs-1.138.0.tgz#125787909419748f208ba3ebce095993779bb579"
-  integrity sha512-O8aazrYCoQ96dapqkfWTW/UMKeq/NFjTysYgbDlrnhGm/Ao/qiLGNrEzKvysLSb2Qzmgv5PPyC4xdFeBtv9ACQ==
-  dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.138.0"
-    "@aws-cdk/aws-iam" "1.138.0"
-    "@aws-cdk/aws-kms" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-ssm@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ssm/-/aws-ssm-1.138.0.tgz#b62ad0f405145248aacc914a4c1e99f53370e89c"
-  integrity sha512-0ZcXq0k0UrEPd4h5A2BsoP21mPtY1ZdEli8aaxkSa5ivyMjVxIrPY6QjUL4FY47DdyRQi3LN5PomiVklpaZUPw==
-  dependencies:
-    "@aws-cdk/aws-iam" "1.138.0"
-    "@aws-cdk/aws-kms" "1.138.0"
-    "@aws-cdk/cloud-assembly-schema" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-stepfunctions@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-stepfunctions/-/aws-stepfunctions-1.138.0.tgz#114f2c83284c21e98626e5b75e4ccd0d599d18c3"
-  integrity sha512-iVYT6uTAscg9Y23uUT/yvVk3PBERmGRxNTvX1K7JpZiu5Fr9lEZSYDvhDu4aMIXc+lKKaKZdQOUFG1GWnlbiKA==
-  dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.138.0"
-    "@aws-cdk/aws-events" "1.138.0"
-    "@aws-cdk/aws-iam" "1.138.0"
-    "@aws-cdk/aws-logs" "1.138.0"
-    "@aws-cdk/aws-s3" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/cfnspec@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cfnspec/-/cfnspec-1.138.0.tgz#4d86ba7476f8545c09954dd30cc3cb877b8b85fb"
-  integrity sha512-eaLYS+TCrc0tQQPuwBRkjoO73vUrBCtVBLYMVRd5fscMW5QFqcZlwDWUBEn4h3pUZsnKfB2L28bCVBCZ7WoJrg==
-  dependencies:
-    fs-extra "^9.1.0"
-    md5 "^2.3.0"
-
-"@aws-cdk/cloud-assembly-schema@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.138.0.tgz#e13af93748306d5f9140a75ac39476110bc0969a"
-  integrity sha512-TnWc0JLgRbj1nHalVkomZb07qdpQZHqz+OSi0wuqvJSEGmt3luqglXzsSNMzKCpJr9muJ5kIkS5+6IM8aavJIg==
-  dependencies:
-    jsonschema "^1.4.0"
-    semver "^7.3.5"
-
-"@aws-cdk/cloudformation-diff@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cloudformation-diff/-/cloudformation-diff-1.138.0.tgz#433399f5c5df41d3c471974689334253cdd5b402"
-  integrity sha512-3iFojfqME8VKLnz8ryS1PNe3EEM7HyErrp4XmYGFNy596kUHeQ/jZ6xmSNe9R+kDXMHHGSYRxK1ilGL2BjBRoA==
-  dependencies:
-    "@aws-cdk/cfnspec" "1.138.0"
-    "@types/node" "^10.17.60"
-    colors "^1.4.0"
-    diff "^5.0.0"
-    fast-deep-equal "^3.1.3"
-    string-width "^4.2.3"
-    table "^6.7.5"
-
-"@aws-cdk/core@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/core/-/core-1.138.0.tgz#d35108bdc947712d59092189895a9fc177d190c2"
-  integrity sha512-BwWYoPWQyVLbhpLzF7BWyEk78ziLyqByXIfJxwIh2hRJTz6IVQmX5UrizcAwxvNcub5lNik0MRLe4oFaLfHfKQ==
-  dependencies:
-    "@aws-cdk/cloud-assembly-schema" "1.138.0"
-    "@aws-cdk/cx-api" "1.138.0"
-    "@aws-cdk/region-info" "1.138.0"
-    "@balena/dockerignore" "^1.0.2"
-    constructs "^3.3.69"
-    fs-extra "^9.1.0"
-    ignore "^5.2.0"
-    minimatch "^3.0.4"
-
-"@aws-cdk/custom-resources@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/custom-resources/-/custom-resources-1.138.0.tgz#983e8b8fa7879efb50a70615f7679b76f2dfee0a"
-  integrity sha512-AEuLPq8FffKR3KUTH9FrJNEK1O0b4QJpwEkVOmRxCdc9oDn3Q35UJvBx1DhamOezBtC3gobml+a0+CWm9cIzng==
-  dependencies:
-    "@aws-cdk/aws-cloudformation" "1.138.0"
-    "@aws-cdk/aws-ec2" "1.138.0"
-    "@aws-cdk/aws-iam" "1.138.0"
-    "@aws-cdk/aws-lambda" "1.138.0"
-    "@aws-cdk/aws-logs" "1.138.0"
-    "@aws-cdk/aws-sns" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/cx-api@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cx-api/-/cx-api-1.138.0.tgz#9efb567d698250129d3c2c00a5ec62d6ab6f9c56"
-  integrity sha512-1JP8ehn7bqUMDpGb0Ce7a6edEUc+U6fnSp7l/SYglKdgu1aIut3nS3refx4opvIzBj4ohNJTW+zPEfnf60hcfg==
-  dependencies:
-    "@aws-cdk/cloud-assembly-schema" "1.138.0"
-    semver "^7.3.5"
-
-"@aws-cdk/lambda-layer-awscli@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/lambda-layer-awscli/-/lambda-layer-awscli-1.138.0.tgz#17f376ba7791b4bdc119e6c0d6790e475a056dd7"
-  integrity sha512-u0y49H9h3gPGUlNT7cI9rfeQGnchTFtDnWqOzQEIsyV6tZfStMUP36ZzF/JaKqEzaDGcTryNYdcDrHHoiX0ncA==
-  dependencies:
-    "@aws-cdk/aws-lambda" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/pipelines@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/pipelines/-/pipelines-1.138.0.tgz#71aa5c33dc6ce448a08426f3ac08ed100cfa89c5"
-  integrity sha512-s+8DQEmsR/iSLcplO8JVTcVz5jBGbs+r0u7ugKdD9D2nn50JI0FEcZ3jcef2n7vYU8WDgcvhHG2PzmHzByEuqg==
-  dependencies:
-    "@aws-cdk/aws-codebuild" "1.138.0"
-    "@aws-cdk/aws-codecommit" "1.138.0"
-    "@aws-cdk/aws-codepipeline" "1.138.0"
-    "@aws-cdk/aws-codepipeline-actions" "1.138.0"
-    "@aws-cdk/aws-ec2" "1.138.0"
-    "@aws-cdk/aws-ecr" "1.138.0"
-    "@aws-cdk/aws-events" "1.138.0"
-    "@aws-cdk/aws-iam" "1.138.0"
-    "@aws-cdk/aws-lambda" "1.138.0"
-    "@aws-cdk/aws-s3" "1.138.0"
-    "@aws-cdk/aws-s3-assets" "1.138.0"
-    "@aws-cdk/aws-secretsmanager" "1.138.0"
-    "@aws-cdk/aws-sns" "1.138.0"
-    "@aws-cdk/cloud-assembly-schema" "1.138.0"
-    "@aws-cdk/core" "1.138.0"
-    "@aws-cdk/cx-api" "1.138.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/region-info@1.138.0":
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/region-info/-/region-info-1.138.0.tgz#fb75036b08f60b96fa9275fd276fc6d388bd3b87"
-  integrity sha512-6evLWOtsgu8VL12EhPgarwJOTJNeNz6KuikwlBqEf+qwcYgYGHkJOOHzlQqPdmtAkRrAfKyGp0pShOvWyCJFcA==
+    jsonschema "~1.4.1"
+    semver "^7.7.4"
 
 "@aws-crypto/ie11-detection@^1.0.0":
   version "1.0.0"
@@ -3528,14 +2715,6 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@jsii/check-node@1.50.0":
-  version "1.50.0"
-  resolved "https://registry.yarnpkg.com/@jsii/check-node/-/check-node-1.50.0.tgz#c1910d39946f8c9e03a936b3c43290088fdf8cd1"
-  integrity sha512-CkL3EtRIxglzPraC2bR+plEw4pxrbCLUZRjTDxALjhJaO67SWyMUhtHkFerPH9vqIe7rQVkvrv6kJTwpNFRU5Q==
-  dependencies:
-    chalk "^4.1.2"
-    semver "^7.3.5"
-
 "@napi-rs/wasm-runtime@^0.2.11":
   version "0.2.12"
   resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz#3e78a8b96e6c33a6c517e1894efbd5385a7cb6f2"
@@ -3737,11 +2916,6 @@
   dependencies:
     tslib "^2.8.0"
 
-"@tootallnate/once@1":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
-  integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
-
 "@tybys/wasm-util@^0.10.0":
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/@tybys/wasm-util/-/wasm-util-0.10.1.tgz#ecddd3205cf1e2d5274649ff0eedd2991ed7f414"
@@ -3883,11 +3057,6 @@
 "@types/node@*":
   version "7.0.29"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.29.tgz#ccfcec5b7135c7caf6c4ffb8c7f33102340d99df"
-
-"@types/node@^10.17.60":
-  version "10.17.60"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.60.tgz#35f3d6213daed95da7f0f73e75bcc6980e90597b"
-  integrity sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==
 
 "@types/node@^20.0.0":
   version "20.19.37"
@@ -4201,13 +3370,6 @@ acorn@^7.4.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
-agent-base@6, agent-base@^6.0.0, agent-base@^6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
-  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
-  dependencies:
-    debug "4"
-
 ajv-keywords@^1.1.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.5.1.tgz#314dd0a4b3368fad3dfcdc54ede6171b886daf3c"
@@ -4320,46 +3482,9 @@ anymatch@^3.1.3:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
-anymatch@~3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.2.tgz#c0557c096af32f106198f4f4e2a383537e378716"
-  integrity sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==
-  dependencies:
-    normalize-path "^3.0.0"
-    picomatch "^2.0.4"
-
 aproba@^1.0.3:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.1.2.tgz#45c6629094de4e96f693ef7eab74ae079c240fc1"
-
-archiver-utils@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/archiver-utils/-/archiver-utils-2.1.0.tgz#e8a460e94b693c3e3da182a098ca6285ba9249e2"
-  integrity sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==
-  dependencies:
-    glob "^7.1.4"
-    graceful-fs "^4.2.0"
-    lazystream "^1.0.0"
-    lodash.defaults "^4.2.0"
-    lodash.difference "^4.5.0"
-    lodash.flatten "^4.4.0"
-    lodash.isplainobject "^4.0.6"
-    lodash.union "^4.6.0"
-    normalize-path "^3.0.0"
-    readable-stream "^2.0.0"
-
-archiver@^5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/archiver/-/archiver-5.3.0.tgz#dd3e097624481741df626267564f7dd8640a45ba"
-  integrity sha512-iUw+oDwK0fgNpvveEsdQ0Ase6IIKztBJU2U0E9MzszMfmVVUyv1QJhS2ITW9ZCqx8dktAxVAjWWkKehuZE8OPg==
-  dependencies:
-    archiver-utils "^2.1.0"
-    async "^3.2.0"
-    buffer-crc32 "^0.2.1"
-    readable-stream "^3.6.0"
-    readdir-glob "^1.0.0"
-    tar-stream "^2.2.0"
-    zip-stream "^4.1.0"
 
 are-we-there-yet@~1.1.2:
   version "1.1.4"
@@ -4437,13 +3562,6 @@ assertion-error@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.0.2.tgz#13ca515d86206da0bac66e834dd397d87581094c"
 
-ast-types@^0.13.2:
-  version "0.13.4"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.13.4.tgz#ee0d77b343263965ecc3fb62da16e7222b2b6782"
-  integrity sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==
-  dependencies:
-    tslib "^2.0.1"
-
 astral-regex@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
@@ -4470,65 +3588,35 @@ async@^2.1.2, async@^2.4.1:
   dependencies:
     lodash "^4.14.0"
 
-async@^3.2.0:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/async/-/async-3.2.1.tgz#d3274ec66d107a47476a4c49136aacdb00665fc8"
-  integrity sha512-XdD5lRO/87udXCMC9meWdYiR+Nq6ZjUfXidViUZGu2F1MO4T3XwZ1et0hb2++BgLfhyJwy44BGB/yx80ABx8hg==
-
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
 
-at-least-node@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
-  integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
-
-aws-cdk@1.138.0:
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/aws-cdk/-/aws-cdk-1.138.0.tgz#792b12c8adab4ec766cd8b6d8031a129e4126c3c"
-  integrity sha512-DBinnNP25EF6fju/M9r+f0+sRRpoFI+qg/stJw9xSfDZIQV4LBePn1o1qfyM0WKaMu7dDkXOHezx/FWd8uSDCg==
+aws-cdk-lib@^2.248.0:
+  version "2.248.0"
+  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.248.0.tgz#2236bb45ad710ac8bfc8affb3f2cbfa93f13c6ae"
+  integrity sha512-PGQycx/OdyX+t0o6QUFI1KJAOLoyIVj2WwrN0syrwCi8lYxW2KzldZsW0X+/UN/ALNQwcjSr927ImTpuDOh+bg==
   dependencies:
-    "@aws-cdk/cloud-assembly-schema" "1.138.0"
-    "@aws-cdk/cloudformation-diff" "1.138.0"
-    "@aws-cdk/cx-api" "1.138.0"
-    "@aws-cdk/region-info" "1.138.0"
-    "@jsii/check-node" "1.50.0"
-    archiver "^5.3.0"
-    aws-sdk "^2.979.0"
-    camelcase "^6.2.1"
-    cdk-assets "1.138.0"
-    chokidar "^3.5.2"
-    colors "^1.4.0"
-    decamelize "^5.0.1"
-    fs-extra "^9.1.0"
-    glob "^7.2.0"
-    json-diff "^0.7.1"
-    minimatch ">=3.0"
-    promptly "^3.2.0"
-    proxy-agent "^5.0.0"
-    semver "^7.3.5"
-    source-map-support "^0.5.21"
-    table "^6.7.5"
-    uuid "^8.3.2"
-    wrap-ansi "^7.0.0"
-    yaml "1.10.2"
-    yargs "^16.2.0"
+    "@aws-cdk/asset-awscli-v1" "2.2.273"
+    "@aws-cdk/asset-node-proxy-agent-v6" "^2.1.1"
+    "@aws-cdk/cloud-assembly-api" "^2.2.0"
+    "@aws-cdk/cloud-assembly-schema" "^53.0.0"
+    "@balena/dockerignore" "^1.0.2"
+    case "1.6.3"
+    fs-extra "^11.3.3"
+    ignore "^5.3.2"
+    jsonschema "^1.5.0"
+    mime-types "^2.1.35"
+    minimatch "^10.2.3"
+    punycode "^2.3.1"
+    semver "^7.7.4"
+    table "^6.9.0"
+    yaml "1.10.3"
 
-aws-sdk@^2.848.0, aws-sdk@^2.979.0:
-  version "2.1004.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1004.0.tgz#5f6bb8859643cbbc50e96f5f27677e6af7b7d7da"
-  integrity sha512-dXcE6HnhV8DH/Jde0lklnZIf3XECFBUX77nPE3ibVU+T8cXdd6gISVR2CEbXANxyx8JVF5l1jdv1nBsUPQtkCA==
-  dependencies:
-    buffer "4.9.2"
-    events "1.1.1"
-    ieee754 "1.1.13"
-    jmespath "0.15.0"
-    querystring "0.2.0"
-    sax "1.2.1"
-    url "0.10.3"
-    uuid "3.3.2"
-    xml2js "0.4.19"
+aws-cdk@^2.248.0:
+  version "2.1118.0"
+  resolved "https://registry.yarnpkg.com/aws-cdk/-/aws-cdk-2.1118.0.tgz#7e12ccb083b26e8d28ed8bd6bffca2af0e73b270"
+  integrity sha512-Tfd865GRewDTXIbTVtix/l+v8t3rZENvdHcQQZS2wXYVXfHzljULFXe9JKkgZUNDPB1zo9tSBUu8jjiHRm7nWg==
 
 aws-sign2@~0.6.0:
   version "0.6.0"
@@ -5128,14 +4216,14 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+balanced-match@^4.0.2:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-4.0.4.tgz#bfb10662feed8196a2c62e7c68e17720c274179a"
+  integrity sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==
+
 base64-js@^1.0.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.2.1.tgz#a91947da1f4a516ea38e5b4ec0ec3773675e0886"
-
-base64-js@^1.3.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
-  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
 baseline-browser-mapping@^2.9.0:
   version "2.10.12"
@@ -5155,20 +4243,6 @@ big.js@^3.1.3:
 binary-extensions@^1.0.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.8.0.tgz#48ec8d16df4377eae5fa5884682480af4d95c774"
-
-binary-extensions@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
-  integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
-
-bl@^4.0.3:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
-  integrity sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
-  dependencies:
-    buffer "^5.5.0"
-    inherits "^2.0.4"
-    readable-stream "^3.4.0"
 
 block-stream@*:
   version "0.0.9"
@@ -5221,6 +4295,13 @@ brace-expansion@^2.0.2:
   dependencies:
     balanced-match "^1.0.0"
 
+brace-expansion@^5.0.5:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.5.tgz#dcc3a37116b79f3e1b46db994ced5d570e930fdb"
+  integrity sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==
+  dependencies:
+    balanced-match "^4.0.2"
+
 braces@^1.8.2:
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/braces/-/braces-1.8.5.tgz#ba77962e12dff969d6b76711e914b737857bf6a7"
@@ -5229,7 +4310,7 @@ braces@^1.8.2:
     preserve "^0.2.0"
     repeat-element "^1.1.2"
 
-braces@^3.0.1, braces@~3.0.2:
+braces@^3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -5320,11 +4401,6 @@ bser@2.1.1:
   dependencies:
     node-int64 "^0.4.0"
 
-buffer-crc32@^0.2.1, buffer-crc32@^0.2.13:
-  version "0.2.13"
-  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
-  integrity sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
-
 buffer-from@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
@@ -5333,15 +4409,6 @@ buffer-from@^1.0.0:
 buffer-xor@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
-
-buffer@4.9.2:
-  version "4.9.2"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8"
-  integrity sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==
-  dependencies:
-    base64-js "^1.0.2"
-    ieee754 "^1.1.4"
-    isarray "^1.0.0"
 
 buffer@^4.3.0:
   version "4.9.1"
@@ -5357,14 +4424,6 @@ buffer@^5.0.3:
   dependencies:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
-
-buffer@^5.5.0:
-  version "5.7.1"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
-  integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
-  dependencies:
-    base64-js "^1.3.1"
-    ieee754 "^1.1.13"
 
 builtin-modules@^1.0.0:
   version "1.1.1"
@@ -5401,7 +4460,7 @@ camelcase@^5.3.1:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
-camelcase@^6.2.1, camelcase@^6.3.0:
+camelcase@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
@@ -5419,19 +4478,6 @@ case@1.6.3:
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
-
-cdk-assets@1.138.0:
-  version "1.138.0"
-  resolved "https://registry.yarnpkg.com/cdk-assets/-/cdk-assets-1.138.0.tgz#66d175bc9ff3b6451256948033a8b917d3d83046"
-  integrity sha512-g0E7aNSN/wt7wpxcH2XDCryAsUPgdhStnyjPswVGj9NpJVh/8DmIMCyN/25FMpHupw7QQCAHzoibs6k/s/f8rA==
-  dependencies:
-    "@aws-cdk/cloud-assembly-schema" "1.138.0"
-    "@aws-cdk/cx-api" "1.138.0"
-    archiver "^5.3.0"
-    aws-sdk "^2.848.0"
-    glob "^7.2.0"
-    mime "^2.6.0"
-    yargs "^16.2.0"
 
 center-align@^0.1.1:
   version "0.1.3"
@@ -5484,11 +4530,6 @@ char-regex@^1.0.2:
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
 
-charenc@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
-  integrity sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=
-
 chokidar@^1.4.3, chokidar@^1.6.1:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468"
@@ -5503,21 +4544,6 @@ chokidar@^1.4.3, chokidar@^1.6.1:
     readdirp "^2.0.0"
   optionalDependencies:
     fsevents "^1.0.0"
-
-chokidar@^3.5.2:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.2.tgz#dba3976fcadb016f66fd365021d91600d01c1e75"
-  integrity sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==
-  dependencies:
-    anymatch "~3.1.2"
-    braces "~3.0.2"
-    glob-parent "~5.1.2"
-    is-binary-path "~2.1.0"
-    is-glob "~4.0.1"
-    normalize-path "~3.0.0"
-    readdirp "~3.6.0"
-  optionalDependencies:
-    fsevents "~2.3.2"
 
 chroma-js@^1.2.1:
   version "1.3.4"
@@ -5539,17 +4565,6 @@ cjs-module-lexer@^2.1.0:
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz#b3ca5101843389259ade7d88c77bd06ce55849ca"
   integrity sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==
 
-cli-color@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/cli-color/-/cli-color-2.0.1.tgz#93e3491308691f1e46beb78b63d0fb2585e42ba6"
-  integrity sha512-eBbxZF6fqPUNnf7CLAFOersUnyYzv83tHFLSlts+OAHsNendaqv2tHCq+/MO+b3Y+9JeoUlIvobyxG/Z8GNeOg==
-  dependencies:
-    d "^1.0.1"
-    es5-ext "^0.10.53"
-    es6-iterator "^2.0.3"
-    memoizee "^0.4.15"
-    timers-ext "^0.1.7"
-
 cliui@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-2.1.0.tgz#4b475760ff80264c762c3a1719032e91c7fea0d1"
@@ -5565,15 +4580,6 @@ cliui@^3.2.0:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
     wrap-ansi "^2.0.0"
-
-cliui@^7.0.2:
-  version "7.0.4"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
-  integrity sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==
-  dependencies:
-    string-width "^4.2.0"
-    strip-ansi "^6.0.0"
-    wrap-ansi "^7.0.0"
 
 cliui@^8.0.1:
   version "8.0.1"
@@ -5621,11 +4627,6 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-colors@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
-  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
-
 combined-stream@^1.0.5, combined-stream@~1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.5.tgz#938370a57b4a51dea2c77c15d5c5fdf895164009"
@@ -5641,16 +4642,6 @@ commander@2.9.0, commander@^2.8.1:
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
-
-compress-commons@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/compress-commons/-/compress-commons-4.1.1.tgz#df2a09a7ed17447642bad10a85cc9a19e5c42a7d"
-  integrity sha512-QLdDLCKNV2dtoTorqgxngQCMA+gWXkM/Nwu7FpeBhk/RdkzimqC3jueb/FDmaZeXh+uby1jkBqE3xArsLBE5wQ==
-  dependencies:
-    buffer-crc32 "^0.2.13"
-    crc32-stream "^4.0.2"
-    normalize-path "^3.0.0"
-    readable-stream "^3.6.0"
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -5670,10 +4661,10 @@ constants-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
 
-constructs@^3.3.69:
-  version "3.3.161"
-  resolved "https://registry.yarnpkg.com/constructs/-/constructs-3.3.161.tgz#9726b1d450f3b9aca7907230f2248e3fd4058ce4"
-  integrity sha512-/27vW3fo0iyb3py4vKI1BduEYmv8vv8uJgLXvI+5F0Jbnn0/E+As2wkGMa7bumhzCd0Ckv/USkAXstGYVXTYQA==
+constructs@^10.0.0:
+  version "10.6.0"
+  resolved "https://registry.yarnpkg.com/constructs/-/constructs-10.6.0.tgz#9ec889c48567182ed9e2a56d4335d582ba0bcb6b"
+  integrity sha512-TxHOnBO5zMo/G76ykzGF/wMpEHu257TbWiIxP9K0Yv/+t70UzgBQiTqjkAsWOPC6jW91DzJI0+ehQV6xDRNBuQ==
 
 content-disposition@0.5.3:
   version "0.5.3"
@@ -5725,22 +4716,6 @@ cors@^2.8.5:
   dependencies:
     object-assign "^4"
     vary "^1"
-
-crc-32@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/crc-32/-/crc-32-1.2.0.tgz#cb2db6e29b88508e32d9dd0ec1693e7b41a18208"
-  integrity sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==
-  dependencies:
-    exit-on-epipe "~1.0.1"
-    printj "~1.1.0"
-
-crc32-stream@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/crc32-stream/-/crc32-stream-4.0.2.tgz#c922ad22b38395abe9d3870f02fa8134ed709007"
-  integrity sha512-DxFZ/Hk473b/muq1VJ///PMNLj0ZMnzye9thBpmjpJKCc5eMgB95aK8zCGrGfQ90cWo561Te6HK9D+j4KPdM6w==
-  dependencies:
-    crc-32 "^1.2.0"
-    readable-stream "^3.4.0"
 
 create-ecdh@^4.0.0:
   version "4.0.0"
@@ -5795,11 +4770,6 @@ cross-spawn@^7.0.3, cross-spawn@^7.0.6:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-crypt@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
-  integrity sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=
-
 cryptiles@2.x.x:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8"
@@ -5838,24 +4808,11 @@ csstype@^3.1.3, csstype@^3.2.2:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.2.3.tgz#ec48c0f3e993e50648c86da559e2610995cf989a"
   integrity sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==
 
-d@1, d@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/d/-/d-1.0.1.tgz#8698095372d58dbee346ffd0c7093f99f8f9eb5a"
-  integrity sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==
-  dependencies:
-    es5-ext "^0.10.50"
-    type "^1.0.1"
-
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
   dependencies:
     assert-plus "^1.0.0"
-
-data-uri-to-buffer@3:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz#594b8973938c5bc2c33046535785341abc4f3636"
-  integrity sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==
 
 date-now@^0.1.4:
   version "0.1.4"
@@ -5874,27 +4831,22 @@ debug@2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
-  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
-  dependencies:
-    ms "2.1.2"
-
 debug@^2.1.1, debug@^2.2.0, debug@^2.4.5:
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
   dependencies:
     ms "2.0.0"
 
+debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
+  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
+  dependencies:
+    ms "2.1.2"
+
 decamelize@^1.0.0, decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
-
-decamelize@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-5.0.1.tgz#db11a92e58c741ef339fb0a2868d8a06a9a7b1e9"
-  integrity sha512-VfxadyCECXgQlkoEAjeghAr5gY3Hf+IKjKb+X8tGVDtveCjN+USwprd2q3QXBR9T1+x2DG0XZF5/w+7HAtSaXA==
 
 decode-uri-component@^0.2.0:
   version "0.2.0"
@@ -5915,7 +4867,7 @@ deep-extend@~0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
 
-deep-is@^0.1.3, deep-is@~0.1.3:
+deep-is@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
@@ -5924,16 +4876,6 @@ deepmerge@^4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.3.1.tgz#44b5f2147cd3b00d4b56137685966f26fd25dd4a"
   integrity sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==
-
-degenerator@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/degenerator/-/degenerator-3.0.1.tgz#7ef78ec0c8577a544477308ddf1d2d6e88d51f5b"
-  integrity sha512-LFsIFEeLPlKvAKXu7j3ssIG6RT0TbI7/GhsqrI0DnHASEQjXQ0LUSYcjJteGgRGmZbl1TnMSxpNQIAiJ7Du5TQ==
-  dependencies:
-    ast-types "^0.13.2"
-    escodegen "^1.8.1"
-    esprima "^4.0.0"
-    vm2 "^3.9.3"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -5975,11 +4917,6 @@ diff@3.2.0, diff@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
 
-diff@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz#7ed6ad76d859d030787ec35855f5b1daf31d852b"
-  integrity sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
-
 diffie-hellman@^5.0.0:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/diffie-hellman/-/diffie-hellman-5.0.2.tgz#b5835739270cfe26acf632099fded2a07f209e5e"
@@ -5987,13 +4924,6 @@ diffie-hellman@^5.0.0:
     bn.js "^4.1.0"
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
-
-difflib@~0.2.1:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/difflib/-/difflib-0.2.4.tgz#b5e30361a6db023176d562892db85940a718f47e"
-  integrity sha1-teMDYabbAjF21WKJLbhZQKcY9H4=
-  dependencies:
-    heap ">= 0.2.0"
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -6012,13 +4942,6 @@ doctrine@^3.0.0:
 domain-browser@^1.1.1:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.1.7.tgz#867aa4b093faa05f1de08c06f4d7b21fdf8698bc"
-
-dreamopt@~0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/dreamopt/-/dreamopt-0.8.0.tgz#5bcc80be7097e45fc489c342405ab68140a8c1d9"
-  integrity sha1-W8yAvnCX5F/EicNCQFq2gUCowdk=
-  dependencies:
-    wordwrap ">=0.0.2"
 
 dynamodb-onetable@^1.9.0:
   version "1.9.0"
@@ -6106,13 +5029,6 @@ encoding@^0.1.11:
   dependencies:
     iconv-lite "~0.4.13"
 
-end-of-stream@^1.4.1:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
-  integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
-  dependencies:
-    once "^1.4.0"
-
 enhanced-resolve@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-3.1.0.tgz#9f4b626f577245edcf4b2ad83d86e17f4f421dec"
@@ -6152,42 +5068,6 @@ error-ex@^1.3.1:
   integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
   dependencies:
     is-arrayish "^0.2.1"
-
-es5-ext@^0.10.35, es5-ext@^0.10.46, es5-ext@^0.10.50, es5-ext@^0.10.53, es5-ext@~0.10.14, es5-ext@~0.10.2, es5-ext@~0.10.46:
-  version "0.10.53"
-  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.53.tgz#93c5a3acfdbef275220ad72644ad02ee18368de1"
-  integrity sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==
-  dependencies:
-    es6-iterator "~2.0.3"
-    es6-symbol "~3.1.3"
-    next-tick "~1.0.0"
-
-es6-iterator@^2.0.3, es6-iterator@~2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
-  integrity sha1-p96IkUGgWpSwhUQDstCg+/qY87c=
-  dependencies:
-    d "1"
-    es5-ext "^0.10.35"
-    es6-symbol "^3.1.1"
-
-es6-symbol@^3.1.1, es6-symbol@~3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.3.tgz#bad5d3c1bcdac28269f4cb331e431c78ac705d18"
-  integrity sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==
-  dependencies:
-    d "^1.0.1"
-    ext "^1.1.2"
-
-es6-weak-map@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/es6-weak-map/-/es6-weak-map-2.0.3.tgz#b6da1f16cc2cc0d9be43e6bdbfc5e7dfcdf31d53"
-  integrity sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==
-  dependencies:
-    d "1"
-    es5-ext "^0.10.46"
-    es6-iterator "^2.0.3"
-    es6-symbol "^3.1.1"
 
 esbuild@^0.11.11:
   version "0.11.23"
@@ -6287,18 +5167,6 @@ escape-string-regexp@^4.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
-escodegen@^1.8.1:
-  version "1.14.3"
-  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.14.3.tgz#4e7b81fba61581dc97582ed78cab7f0e8d63f503"
-  integrity sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==
-  dependencies:
-    esprima "^4.0.1"
-    estraverse "^4.2.0"
-    esutils "^2.0.2"
-    optionator "^0.8.1"
-  optionalDependencies:
-    source-map "~0.6.1"
-
 eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
@@ -6386,7 +5254,7 @@ espree@^7.3.0, espree@^7.3.1:
     acorn-jsx "^5.3.1"
     eslint-visitor-keys "^1.3.0"
 
-esprima@^4.0.0, esprima@^4.0.1:
+esprima@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
@@ -6405,7 +5273,7 @@ esrecurse@^4.3.0:
   dependencies:
     estraverse "^5.2.0"
 
-estraverse@^4.1.1, estraverse@^4.2.0:
+estraverse@^4.1.1:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
@@ -6424,15 +5292,7 @@ etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
 
-event-emitter@^0.3.5:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/event-emitter/-/event-emitter-0.3.5.tgz#df8c69eef1647923c7157b9ce83840610b02cc39"
-  integrity sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=
-  dependencies:
-    d "1"
-    es5-ext "~0.10.14"
-
-events@1.1.1, events@^1.0.0:
+events@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
 
@@ -6456,11 +5316,6 @@ execa@^5.1.1:
     onetime "^5.1.2"
     signal-exit "^3.0.3"
     strip-final-newline "^2.0.0"
-
-exit-on-epipe@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz#0bdd92e87d5285d267daa8171d0eb06159689692"
-  integrity sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==
 
 exit-x@^0.2.2:
   version "0.2.2"
@@ -6531,13 +5386,6 @@ express@^4.17.1:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
-ext@^1.1.2:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/ext/-/ext-1.6.0.tgz#3871d50641e874cc172e2b53f919842d19db4c52"
-  integrity sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==
-  dependencies:
-    type "^2.5.0"
-
 extend@~3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
@@ -6573,7 +5421,7 @@ fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0, fast-json-sta
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
-fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
+fast-levenshtein@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
@@ -6620,11 +5468,6 @@ file-entry-cache@^6.0.1:
   integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
   dependencies:
     flat-cache "^3.0.4"
-
-file-uri-to-path@2:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-2.0.0.tgz#7b415aeba227d575851e0a5b0c640d7656403fba"
-  integrity sha512-hjPFI8oE/2iQPVe4gbrJ73Pp+Xfub2+WI2LlXDbsaJBwT5wuMh35WNWVYYTpnz895shtwfyutMFLFywpQAFdLg==
 
 filename-regex@^2.0.0:
   version "2.0.1"
@@ -6748,26 +5591,11 @@ fresh@0.5.2:
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
 
-fs-constants@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
-  integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
-
-fs-extra@^8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
-  integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
+fs-extra@^11.3.3:
+  version "11.3.4"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.3.4.tgz#ab6934eca8bcf6f7f6b82742e33591f86301d6fc"
+  integrity sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==
   dependencies:
-    graceful-fs "^4.2.0"
-    jsonfile "^4.0.0"
-    universalify "^0.1.0"
-
-fs-extra@^9.1.0:
-  version "9.1.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
-  integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
-  dependencies:
-    at-least-node "^1.0.0"
     graceful-fs "^4.2.0"
     jsonfile "^6.0.1"
     universalify "^2.0.0"
@@ -6813,14 +5641,6 @@ fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2:
     inherits "~2.0.0"
     mkdirp ">=0.5 0"
     rimraf "2"
-
-ftp@^0.3.10:
-  version "0.3.10"
-  resolved "https://registry.yarnpkg.com/ftp/-/ftp-0.3.10.tgz#9197d861ad8142f3e63d5a83bfe4c59f7330885d"
-  integrity sha1-kZfYYa2BQvPmPVqDv+TFn3MwiF0=
-  dependencies:
-    readable-stream "1.1.x"
-    xregexp "2.0.0"
 
 functional-red-black-tree@^1.0.1:
   version "1.0.1"
@@ -6871,18 +5691,6 @@ get-tsconfig@^4.7.5:
   dependencies:
     resolve-pkg-maps "^1.0.0"
 
-get-uri@3:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/get-uri/-/get-uri-3.0.2.tgz#f0ef1356faabc70e1f9404fa3b66b2ba9bfc725c"
-  integrity sha512-+5s0SJbGoyiJTZZ2JTpFPLMPSch72KEqGOTvQsBqg0RBWvwhWUSYZFAtz3TPW0GXJuLBJPts1E241iHg+VRfhg==
-  dependencies:
-    "@tootallnate/once" "1"
-    data-uri-to-buffer "3"
-    debug "4"
-    file-uri-to-path "2"
-    fs-extra "^8.1.0"
-    ftp "^0.3.10"
-
 getpass@^0.1.1:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
@@ -6902,7 +5710,7 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob-parent@^5.1.2, glob-parent@~5.1.2:
+glob-parent@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -6943,7 +5751,7 @@ glob@^7.0.0, glob@^7.0.5, glob@^7.1.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.1.3, glob@^7.1.4, glob@^7.2.0:
+glob@^7.1.3, glob@^7.1.4:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
   integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
@@ -7077,11 +5885,6 @@ hawk@~3.1.3:
     hoek "2.x.x"
     sntp "1.x.x"
 
-"heap@>= 0.2.0":
-  version "0.2.6"
-  resolved "https://registry.yarnpkg.com/heap/-/heap-0.2.6.tgz#087e1f10b046932fc8594dd9e6d378afc9d1e5ac"
-  integrity sha1-CH4fELBGky/IWU3Z5tN4r8nR5aw=
-
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -7125,7 +5928,7 @@ http-errors@1.7.2:
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
 
-http-errors@1.7.3, http-errors@~1.7.2:
+http-errors@~1.7.2:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.7.3.tgz#6c619e4f9c60308c38519498c14fbb10aacebb06"
   integrity sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==
@@ -7135,15 +5938,6 @@ http-errors@1.7.3, http-errors@~1.7.2:
     setprototypeof "1.1.1"
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
-
-http-proxy-agent@^4.0.0, http-proxy-agent@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz#8a8c8ef7f5932ccf953c296ca8291b95aa74aa3a"
-  integrity sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==
-  dependencies:
-    "@tootallnate/once" "1"
-    agent-base "6"
-    debug "4"
 
 http-signature@~1.1.0:
   version "1.1.1"
@@ -7156,14 +5950,6 @@ http-signature@~1.1.0:
 https-browserify@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-0.0.1.tgz#3f91365cabe60b77ed0ebba24b454e3e09d95a82"
-
-https-proxy-agent@5, https-proxy-agent@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2"
-  integrity sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==
-  dependencies:
-    agent-base "6"
-    debug "4"
 
 human-signals@^2.1.0:
   version "2.1.0"
@@ -7185,16 +5971,6 @@ iconv-lite@~0.4.13:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
-ieee754@1.1.13:
-  version "1.1.13"
-  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
-  integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
-
-ieee754@^1.1.13:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
-  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
-
 ieee754@^1.1.4:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
@@ -7209,10 +5985,10 @@ ignore@^5.1.4, ignore@^5.1.8:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
-ignore@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
-  integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
+ignore@^5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.2.tgz#3cd40e729f3643fd87cb04e50bf0eb722bc596f5"
+  integrity sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
 
 import-fresh@^3.0.0, import-fresh@^3.2.1:
   version "3.3.0"
@@ -7261,7 +6037,7 @@ inherits@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
 
-inherits@2.0.4, inherits@^2.0.3, inherits@^2.0.4:
+inherits@2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -7284,11 +6060,6 @@ invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
 
-ip@^1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
-  integrity sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=
-
 ipaddr.js@1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
@@ -7308,21 +6079,9 @@ is-binary-path@^1.0.0:
   dependencies:
     binary-extensions "^1.0.0"
 
-is-binary-path@~2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
-  integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
-  dependencies:
-    binary-extensions "^2.0.0"
-
 is-buffer@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.5.tgz#1f3b26ef613b214b88cbca23cc6c01d87961eecc"
-
-is-buffer@~1.1.6:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
-  integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
 is-builtin-module@^1.0.0:
   version "1.0.0"
@@ -7385,7 +6144,7 @@ is-glob@^2.0.0, is-glob@^2.0.1:
   dependencies:
     is-extglob "^1.0.0"
 
-is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
+is-glob@^4.0.0, is-glob@^4.0.1:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
@@ -7416,11 +6175,6 @@ is-posix-bracket@^0.1.0:
 is-primitive@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
-
-is-promise@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.2.2.tgz#39ab959ccbf9a774cf079f7b40c7a26f763135f1"
-  integrity sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==
 
 is-stream@^1.0.1:
   version "1.1.0"
@@ -7884,11 +6638,6 @@ jest@^30.0.0:
     import-local "^3.2.0"
     jest-cli "30.3.0"
 
-jmespath@0.15.0:
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
-  integrity sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=
-
 js-tokens@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
@@ -7922,15 +6671,6 @@ jsesc@^3.0.2:
 jsesc@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
-
-json-diff@^0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/json-diff/-/json-diff-0.7.1.tgz#0f1a87d281174c1a62c8714a208d0d24725a8169"
-  integrity sha512-/LxjcgeDIZwFB1HHTShKAYs2NaxAgwUQjXKvrFLDvw3KqvbffFmy5ZeeamxoSLgQG89tRs9+CFKiR3lJAPPhDw==
-  dependencies:
-    cli-color "^2.0.0"
-    difflib "~0.2.1"
-    dreamopt "~0.8.0"
 
 json-loader@^0.5.4:
   version "0.5.4"
@@ -7983,13 +6723,6 @@ json5@^2.2.3:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
-jsonfile@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
-  integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
-  optionalDependencies:
-    graceful-fs "^4.1.6"
-
 jsonfile@^6.0.1:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
@@ -8003,10 +6736,15 @@ jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
 
-jsonschema@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.4.0.tgz#1afa34c4bc22190d8e42271ec17ac8b3404f87b2"
-  integrity sha512-/YgW6pRMr6M7C+4o8kS+B/2myEpHCrxO4PEWnqJNBFMjn7EWXqlQ4tGwL6xTHeRplwuZmcAncdvfOad1nT2yMw==
+jsonschema@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.5.0.tgz#f6aceb1ab9123563dd901d05f81f9d4883d3b7d8"
+  integrity sha512-K+A9hhqbn0f3pJX17Q/7H6yQfD/5OXgdrR5UE12gMXCiN9D5Xq2o5mddV2QEcX/bjla99ASsAAQUyMCCRWAEhw==
+
+jsonschema@~1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.4.1.tgz#cc4c3f0077fb4542982973d8a083b6b34f482dab"
+  integrity sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==
 
 jsprim@^1.2.2:
   version "1.4.0"
@@ -8032,13 +6770,6 @@ lazy-cache@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
 
-lazystream@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/lazystream/-/lazystream-1.0.0.tgz#f6995fe0f820392f61396be89462407bb77168e4"
-  integrity sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=
-  dependencies:
-    readable-stream "^2.0.5"
-
 lcid@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835"
@@ -8057,14 +6788,6 @@ levn@^0.4.1:
   dependencies:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
-
-levn@~0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
-  integrity sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=
-  dependencies:
-    prelude-ls "~1.1.2"
-    type-check "~0.3.2"
 
 lines-and-columns@^1.1.6:
   version "1.1.6"
@@ -8145,21 +6868,6 @@ lodash.create@3.1.1:
     lodash._basecreate "^3.0.0"
     lodash._isiterateecall "^3.0.0"
 
-lodash.defaults@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
-  integrity sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=
-
-lodash.difference@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.difference/-/lodash.difference-4.5.0.tgz#9ccb4e505d486b91651345772885a2df27fd017c"
-  integrity sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=
-
-lodash.flatten@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
-  integrity sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=
-
 lodash.isarguments@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
@@ -8167,11 +6875,6 @@ lodash.isarguments@^3.0.0:
 lodash.isarray@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
-
-lodash.isplainobject@^4.0.6:
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
-  integrity sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=
 
 lodash.keys@^3.0.0:
   version "3.1.2"
@@ -8195,11 +6898,6 @@ lodash.truncate@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
-
-lodash.union@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.union/-/lodash.union-4.6.0.tgz#48bb5088409f16f1821666641c44dd1aaae3cd88"
-  integrity sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=
 
 lodash@^4.14.0, lodash@^4.2.0:
   version "4.17.4"
@@ -8238,13 +6936,6 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-lru-queue@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/lru-queue/-/lru-queue-0.1.0.tgz#2738bd9f0d3cf4f84490c5736c48699ac632cda3"
-  integrity sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=
-  dependencies:
-    es5-ext "~0.10.2"
-
 magic-string@^0.19.0:
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.19.1.tgz#14d768013caf2ec8fdea16a49af82fc377e75201"
@@ -8270,32 +6961,9 @@ makeerror@1.0.12:
   dependencies:
     tmpl "1.0.5"
 
-md5@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/md5/-/md5-2.3.0.tgz#c3da9a6aae3a30b46b7b0c349b87b110dc3bda4f"
-  integrity sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==
-  dependencies:
-    charenc "0.0.2"
-    crypt "0.0.2"
-    is-buffer "~1.1.6"
-
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
-
-memoizee@^0.4.15:
-  version "0.4.15"
-  resolved "https://registry.yarnpkg.com/memoizee/-/memoizee-0.4.15.tgz#e6f3d2da863f318d02225391829a6c5956555b72"
-  integrity sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==
-  dependencies:
-    d "^1.0.1"
-    es5-ext "^0.10.53"
-    es6-weak-map "^2.0.3"
-    event-emitter "^0.3.5"
-    is-promise "^2.2.2"
-    lru-queue "^0.1.0"
-    next-tick "^1.1.0"
-    timers-ext "^0.1.7"
 
 memory-fs@^0.4.0, memory-fs@~0.4.1:
   version "0.4.1"
@@ -8373,6 +7041,11 @@ mime-db@1.50.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.50.0.tgz#abd4ac94e98d3c0e185016c67ab45d5fde40c11f"
   integrity sha512-9tMZCDlYHqeERXEHO9f/hKfNXhre5dK2eE/krIvUjZbS2KPcqGDfNShIWS1uW9XOTKQKqK6qbeOci18rbfW77A==
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
 mime-db@~1.27.0:
   version "1.27.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.27.0.tgz#820f572296bbd20ec25ed55e5b5de869e5436eb1"
@@ -8382,6 +7055,13 @@ mime-types@^2.1.12, mime-types@~2.1.7:
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.15.tgz#a4ebf5064094569237b8cf70046776d09fc92aed"
   dependencies:
     mime-db "~1.27.0"
+
+mime-types@^2.1.35:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
 
 mime-types@~2.1.24:
   version "2.1.33"
@@ -8394,11 +7074,6 @@ mime@1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
-
-mime@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-2.6.0.tgz#a2a682a95cd4d0cb1d6257e28f83da7e35800367"
-  integrity sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==
 
 mimic-fn@^2.1.0:
   version "2.1.0"
@@ -8413,7 +7088,14 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
 
-minimatch@>=3.0, minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.4:
+minimatch@^10.2.3:
+  version "10.2.5"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.5.tgz#bd48687a0be38ed2961399105600f832095861d1"
+  integrity sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==
+  dependencies:
+    brace-expansion "^5.0.5"
+
+minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -8501,11 +7183,6 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-mute-stream@~0.0.4:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
-  integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
-
 nan@^2.3.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.6.2.tgz#e4ff34e6c95fdfb5aecc08de6596f43605a7db45"
@@ -8538,21 +7215,6 @@ neo-async@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
-
-netmask@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/netmask/-/netmask-2.0.2.tgz#8b01a07644065d536383835823bc52004ebac5e7"
-  integrity sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==
-
-next-tick@1, next-tick@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.1.0.tgz#1836ee30ad56d67ef281b22bd199f709449b35eb"
-  integrity sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==
-
-next-tick@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
-  integrity sha1-yobR/ogoFpsBICCOPchCS524NCw=
 
 node-fetch@^1.0.1:
   version "1.7.3"
@@ -8633,7 +7295,7 @@ normalize-path@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.0.1.tgz#47886ac1662760d4261b7d979d241709d3ce3f7a"
 
-normalize-path@^3.0.0, normalize-path@~3.0.0:
+normalize-path@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
@@ -8685,7 +7347,7 @@ on-finished@~2.3.0:
   dependencies:
     ee-first "1.1.1"
 
-once@^1.3.0, once@^1.3.3, once@^1.4.0:
+once@^1.3.0, once@^1.3.3:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   dependencies:
@@ -8697,18 +7359,6 @@ onetime@^5.1.2:
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
-
-optionator@^0.8.1:
-  version "0.8.3"
-  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.3.tgz#84fa1d036fe9d3c7e21d99884b601167ec8fb495"
-  integrity sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==
-  dependencies:
-    deep-is "~0.1.3"
-    fast-levenshtein "~2.0.6"
-    levn "~0.3.0"
-    prelude-ls "~1.1.2"
-    type-check "~0.3.2"
-    word-wrap "~1.2.3"
 
 optionator@^0.9.1:
   version "0.9.1"
@@ -8780,30 +7430,6 @@ p-try@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
-
-pac-proxy-agent@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/pac-proxy-agent/-/pac-proxy-agent-5.0.0.tgz#b718f76475a6a5415c2efbe256c1c971c84f635e"
-  integrity sha512-CcFG3ZtnxO8McDigozwE3AqAw15zDvGH+OjXO4kzf7IkEKkQ4gxQ+3sdF50WmhQ4P/bVusXcqNE2S3XrNURwzQ==
-  dependencies:
-    "@tootallnate/once" "1"
-    agent-base "6"
-    debug "4"
-    get-uri "3"
-    http-proxy-agent "^4.0.1"
-    https-proxy-agent "5"
-    pac-resolver "^5.0.0"
-    raw-body "^2.2.0"
-    socks-proxy-agent "5"
-
-pac-resolver@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/pac-resolver/-/pac-resolver-5.0.0.tgz#1d717a127b3d7a9407a16d6e1b012b13b9ba8dc0"
-  integrity sha512-H+/A6KitiHNNW+bxBKREk2MCGSxljfqRX76NjummWEYIat7ldVXRU3dhRIE3iXZ0nvGBk6smv3nntxKkzRL8NA==
-  dependencies:
-    degenerator "^3.0.1"
-    ip "^1.1.5"
-    netmask "^2.0.1"
 
 package-json-from-dist@^1.0.0:
   version "1.0.1"
@@ -8952,11 +7578,6 @@ picomatch@^2.0.4, picomatch@^2.2.3:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972"
   integrity sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==
 
-picomatch@^2.2.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
-  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
-
 picomatch@^4.0.2, picomatch@^4.0.3:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
@@ -9012,11 +7633,6 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
-prelude-ls@~1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
-  integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
-
 preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
@@ -9030,11 +7646,6 @@ pretty-format@30.3.0, pretty-format@^30.0.0:
     ansi-styles "^5.2.0"
     react-is "^18.3.1"
 
-printj@~1.1.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/printj/-/printj-1.1.2.tgz#d90deb2975a8b9f600fb3a1c94e3f4c53c78a222"
-  integrity sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==
-
 private@^0.1.6:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.7.tgz#68ce5e8a1ef0a23bb570cc28537b5332aba63ef1"
@@ -9042,11 +7653,6 @@ private@^0.1.6:
 process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
-
-process-nextick-args@~2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
-  integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
 process@^0.11.0:
   version "0.11.10"
@@ -9063,13 +7669,6 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-promptly@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/promptly/-/promptly-3.2.0.tgz#a5517fbbf59bd31c1751d4e1d9bef1714f42b9d8"
-  integrity sha512-WnR9obtgW+rG4oUV3hSnNGl1pHm3V1H/qD9iJBumGSmVsSC5HpZOLuu8qdMb6yCItGfT7dcRszejr/5P3i9Pug==
-  dependencies:
-    read "^1.0.4"
-
 prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
@@ -9085,25 +7684,6 @@ proxy-addr@~2.0.5:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
-
-proxy-agent@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/proxy-agent/-/proxy-agent-5.0.0.tgz#d31405c10d6e8431fde96cba7a0c027ce01d633b"
-  integrity sha512-gkH7BkvLVkSfX9Dk27W6TyNOWWZWRilRfk1XxGNWOYJ2TuedAv1yFpCaU9QSBmBe716XOTNpYNOzhysyw8xn7g==
-  dependencies:
-    agent-base "^6.0.0"
-    debug "4"
-    http-proxy-agent "^4.0.0"
-    https-proxy-agent "^5.0.0"
-    lru-cache "^5.1.1"
-    pac-proxy-agent "^5.0.0"
-    proxy-from-env "^1.0.0"
-    socks-proxy-agent "^5.0.0"
-
-proxy-from-env@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
-  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 prr@~0.0.0:
   version "0.0.0"
@@ -9127,10 +7707,15 @@ punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
-punycode@^2.1.0, punycode@^2.1.1:
+punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
+punycode@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
+  integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
 pure-rand@^7.0.0:
   version "7.0.1"
@@ -9202,16 +7787,6 @@ raw-body@2.4.0:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-raw-body@^2.2.0:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.4.1.tgz#30ac82f98bb5ae8c152e67149dac8d55153b168c"
-  integrity sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==
-  dependencies:
-    bytes "3.1.0"
-    http-errors "1.7.3"
-    iconv-lite "0.4.24"
-    unpipe "1.0.0"
-
 rc@^1.1.7:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.1.tgz#2e03e8e42ee450b8cb3dce65be1bf8974e1dfd95"
@@ -9277,36 +7852,6 @@ read-pkg@^1.0.0:
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
 
-read@^1.0.4:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/read/-/read-1.0.7.tgz#b3da19bd052431a97671d44a42634adf710b40c4"
-  integrity sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=
-  dependencies:
-    mute-stream "~0.0.4"
-
-readable-stream@1.1.x:
-  version "1.1.14"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
-  integrity sha1-fPTFTvZI44EwhMY23SB54WbAgdk=
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "0.0.1"
-    string_decoder "~0.10.x"
-
-readable-stream@^2.0.0:
-  version "2.3.7"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
-  integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.3"
-    isarray "~1.0.0"
-    process-nextick-args "~2.0.0"
-    safe-buffer "~5.1.1"
-    string_decoder "~1.1.1"
-    util-deprecate "~1.0.1"
-
 readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.2.6:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
@@ -9319,22 +7864,6 @@ readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable
     string_decoder "~1.0.3"
     util-deprecate "~1.0.1"
 
-readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
-  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
-  dependencies:
-    inherits "^2.0.3"
-    string_decoder "^1.1.1"
-    util-deprecate "^1.0.1"
-
-readdir-glob@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/readdir-glob/-/readdir-glob-1.1.1.tgz#f0e10bb7bf7bfa7e0add8baffdc54c3f7dbee6c4"
-  integrity sha512-91/k1EzZwDx6HbERR+zucygRFfiPl2zkIYZtv3Jjr6Mn7SkKcVct8aVO+sSRiGMc6fLf72du3d92/uY63YPdEA==
-  dependencies:
-    minimatch "^3.0.4"
-
 readdirp@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-2.1.0.tgz#4ed0ad060df3073300c48440373f72d1cc642d78"
@@ -9343,13 +7872,6 @@ readdirp@^2.0.0:
     minimatch "^3.0.2"
     readable-stream "^2.0.2"
     set-immediate-shim "^1.0.1"
-
-readdirp@~3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
-  integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
-  dependencies:
-    picomatch "^2.2.1"
 
 rebass@^1.0.4:
   version "1.0.4"
@@ -9586,11 +8108,6 @@ safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
-safe-buffer@~5.2.0:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
-  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
-
 "safer-buffer@>= 2.1.2 < 3":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
@@ -9599,16 +8116,6 @@ safe-buffer@~5.2.0:
 samsam@1.x, samsam@^1.1.3:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.2.1.tgz#edd39093a3184370cb859243b2bdf255e7d8ea67"
-
-sax@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
-  integrity sha1-e45lYZCyKOgaZq6nSEgNgozS03o=
-
-sax@>=0.6.0:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
-  integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
 scheduler@^0.27.0:
   version "0.27.0"
@@ -9636,7 +8143,7 @@ semver@^7.2.1, semver@^7.3.5:
   dependencies:
     lru-cache "^6.0.0"
 
-semver@^7.5.4, semver@^7.7.2, semver@^7.7.3:
+semver@^7.5.4, semver@^7.7.2, semver@^7.7.3, semver@^7.7.4:
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.4.tgz#28464e36060e991fa7a11d0279d2d3f3b57a7e8a"
   integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
@@ -9750,33 +8257,11 @@ slice-ansi@^4.0.0:
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
 
-smart-buffer@^4.1.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.2.0.tgz#6e1d71fa4f18c05f7d0ff216dd16a481d0e8d9ae"
-  integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
-
 sntp@1.x.x:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/sntp/-/sntp-1.0.9.tgz#6541184cc90aeea6c6e7b35e2659082443c66198"
   dependencies:
     hoek "2.x.x"
-
-socks-proxy-agent@5, socks-proxy-agent@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-5.0.1.tgz#032fb583048a29ebffec2e6a73fca0761f48177e"
-  integrity sha512-vZdmnjb9a2Tz6WEQVIurybSwElwPxMZaIc7PzqbJTrezcKNznv6giT7J7tZDZ1BojVaa1jvO/UiUdhDVB0ACoQ==
-  dependencies:
-    agent-base "^6.0.2"
-    debug "4"
-    socks "^2.3.3"
-
-socks@^2.3.3:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/socks/-/socks-2.6.1.tgz#989e6534a07cf337deb1b1c94aaa44296520d30e"
-  integrity sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==
-  dependencies:
-    ip "^1.1.5"
-    smart-buffer "^4.1.0"
 
 source-list-map@^1.1.1:
   version "1.1.2"
@@ -9817,19 +8302,11 @@ source-map-support@^0.5.16:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
-source-map-support@^0.5.21:
-  version "0.5.21"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
-  integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
-  dependencies:
-    buffer-from "^1.0.0"
-    source-map "^0.6.0"
-
 source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1, source-map@~0.5.3:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 
-source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
+source-map@^0.6.0, source-map@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
@@ -9949,27 +8426,13 @@ string-width@^5.0.1, string-width@^5.1.2:
     emoji-regex "^9.2.2"
     strip-ansi "^7.0.1"
 
-string_decoder@^0.10.25, string_decoder@~0.10.x:
+string_decoder@^0.10.25:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
-
-string_decoder@^1.1.1:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
-  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
-  dependencies:
-    safe-buffer "~5.2.0"
 
 string_decoder@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
-  dependencies:
-    safe-buffer "~5.1.0"
-
-string_decoder@~1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
-  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
   dependencies:
     safe-buffer "~5.1.0"
 
@@ -10118,10 +8581,10 @@ table@^6.0.9:
     string-width "^4.2.3"
     strip-ansi "^6.0.1"
 
-table@^6.7.5:
-  version "6.7.5"
-  resolved "https://registry.yarnpkg.com/table/-/table-6.7.5.tgz#f04478c351ef3d8c7904f0e8be90a1b62417d238"
-  integrity sha512-LFNeryOqiQHqCVKzhkymKwt6ozeRhlm8IL1mE8rNUurkir4heF6PzMyRgaTa4tlyPTGGgXuvVOF/OLWiH09Lqw==
+table@^6.9.0:
+  version "6.9.0"
+  resolved "https://registry.yarnpkg.com/table/-/table-6.9.0.tgz#50040afa6264141c7566b3b81d4d82c47a8668f5"
+  integrity sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==
   dependencies:
     ajv "^8.0.1"
     lodash.truncate "^4.4.2"
@@ -10160,17 +8623,6 @@ tar-pack@^3.4.0:
     tar "^2.2.1"
     uid-number "^0.0.6"
 
-tar-stream@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.2.0.tgz#acad84c284136b060dc3faa64474aa9aebd77287"
-  integrity sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==
-  dependencies:
-    bl "^4.0.3"
-    end-of-stream "^1.4.1"
-    fs-constants "^1.0.0"
-    inherits "^2.0.3"
-    readable-stream "^3.1.1"
-
 tar@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.1.tgz#8e4d2a256c0e2185c6b18ad694aec968b83cb1d1"
@@ -10202,14 +8654,6 @@ timers-browserify@^2.0.2:
   resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.2.tgz#ab4883cf597dcd50af211349a00fbca56ac86b86"
   dependencies:
     setimmediate "^1.0.4"
-
-timers-ext@^0.1.7:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/timers-ext/-/timers-ext-0.1.7.tgz#6f57ad8578e07a3fb9f91d9387d65647555e25c6"
-  integrity sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==
-  dependencies:
-    es5-ext "~0.10.46"
-    next-tick "1"
 
 tinyglobby@^0.2.13:
   version "0.2.15"
@@ -10279,15 +8723,15 @@ tslib@^1.11.1, tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.1, tslib@^2.3.0:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
-  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
-
 tslib@^2.1.0, tslib@^2.4.0, tslib@^2.8.0, tslib@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
+
+tslib@^2.3.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tsutils@^3.21.0:
   version "3.21.0"
@@ -10326,13 +8770,6 @@ type-check@^0.4.0, type-check@~0.4.0:
   integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
   dependencies:
     prelude-ls "^1.2.1"
-
-type-check@~0.3.2:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
-  integrity sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=
-  dependencies:
-    prelude-ls "~1.1.2"
 
 type-detect@0.1.1:
   version "0.1.1"
@@ -10374,16 +8811,6 @@ type-is@~1.6.17, type-is@~1.6.18:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-type@^1.0.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/type/-/type-1.2.0.tgz#848dd7698dafa3e54a6c479e759c4bc3f18847a0"
-  integrity sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==
-
-type@^2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/type/-/type-2.5.0.tgz#0a2e78c2e77907b252abe5f298c1b01c63f0db3d"
-  integrity sha512-180WMDQaIMm3+7hGXWf12GtdniDEy7nYcyFMKJn/eZz/6tSLXrUN9V0wKSbMjej0I1WHWbpREDEKHtqPQa9NNw==
-
 typescript@^6.0.0:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.2.tgz#0b1bfb15f68c64b97032f3d78abbf98bdbba501f"
@@ -10423,11 +8850,6 @@ undici-types@~6.21.0:
   version "6.21.0"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
   integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
-
-universalify@^0.1.0:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
-  integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
 universalify@^2.0.0:
   version "2.0.0"
@@ -10480,14 +8902,6 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-url@0.10.3:
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64"
-  integrity sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=
-  dependencies:
-    punycode "1.3.2"
-    querystring "0.2.0"
-
 url@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
@@ -10504,7 +8918,7 @@ user-home@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/user-home/-/user-home-1.1.1.tgz#2b5be23a32b63a7c9deb8d0f28d485724a3df190"
 
-util-deprecate@^1.0.1, util-deprecate@~1.0.1:
+util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 
@@ -10518,11 +8932,6 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
-
-uuid@3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
-  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
 uuid@^3.0.0, uuid@^3.0.1:
   version "3.0.1"
@@ -10594,11 +9003,6 @@ vm-browserify@0.0.4:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-0.0.4.tgz#5d7ea45bbef9e4a6ff65f95438e0a87c357d5a73"
   dependencies:
     indexof "0.0.1"
-
-vm2@^3.9.3:
-  version "3.9.3"
-  resolved "https://registry.yarnpkg.com/vm2/-/vm2-3.9.3.tgz#29917f6cc081cc43a3f580c26c5b553fd3c91f40"
-  integrity sha512-smLS+18RjXYMl9joyJxMNI9l4w7biW8ilSDaVRvFBDwOH8P0BK1ognFQTpg0wyQ6wIKLTblHJvROW692L/E53Q==
 
 walker@^1.0.8:
   version "1.0.8"
@@ -10673,7 +9077,7 @@ window-size@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
 
-word-wrap@^1.2.3, word-wrap@~1.2.3:
+word-wrap@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
@@ -10682,7 +9086,7 @@ wordwrap@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.2.tgz#b79669bb42ecb409f83d583cad52ca17eaa1643f"
 
-wordwrap@>=0.0.2, wordwrap@^1.0.0:
+wordwrap@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
@@ -10733,24 +9137,6 @@ write-file-atomic@^5.0.1:
     imurmurhash "^0.1.4"
     signal-exit "^4.0.1"
 
-xml2js@0.4.19:
-  version "0.4.19"
-  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
-  integrity sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==
-  dependencies:
-    sax ">=0.6.0"
-    xmlbuilder "~9.0.1"
-
-xmlbuilder@~9.0.1:
-  version "9.0.7"
-  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
-  integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
-
-xregexp@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/xregexp/-/xregexp-2.0.0.tgz#52a63e56ca0b84a7f3a5f3d61872f126ad7a5943"
-  integrity sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM=
-
 xtend@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
@@ -10774,15 +9160,10 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yaml@1.10.2:
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
-  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
-
-yargs-parser@^20.2.2:
-  version "20.2.9"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
-  integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
+yaml@1.10.3:
+  version "1.10.3"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.3.tgz#76e407ed95c42684fb8e14641e5de62fe65bbcb3"
+  integrity sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==
 
 yargs-parser@^21.1.1:
   version "21.1.1"
@@ -10794,19 +9175,6 @@ yargs-parser@^4.2.0:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-4.2.1.tgz#29cceac0dc4f03c6c87b4a9f217dd18c9f74871c"
   dependencies:
     camelcase "^3.0.0"
-
-yargs@^16.2.0:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
-  integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
-  dependencies:
-    cliui "^7.0.2"
-    escalade "^3.1.1"
-    get-caller-file "^2.0.5"
-    require-directory "^2.1.1"
-    string-width "^4.2.0"
-    y18n "^5.0.5"
-    yargs-parser "^20.2.2"
 
 yargs@^17.7.2:
   version "17.7.2"
@@ -10852,12 +9220,3 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
-
-zip-stream@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/zip-stream/-/zip-stream-4.1.0.tgz#51dd326571544e36aa3f756430b313576dc8fc79"
-  integrity sha512-zshzwQW7gG7hjpBlgeQP9RuyPGNxvJdzR8SUM3QhxCnLjWN2E7j3dOvpeDcQoETfHx0urRS7EtmVToql7YpU4A==
-  dependencies:
-    archiver-utils "^2.1.0"
-    compress-commons "^4.1.0"
-    readable-stream "^3.6.0"


### PR DESCRIPTION
## Purpose 🎯 

Bring `@battle/ops` up-to-date

## Context 💭 

- Fix TypeScript issue for `@battle/game` where `@types/react` conflict between 15 and 19
- Update docker builds to Node 24
- Increase memory size of CodeBuild to solve OOM from new `@battle/gamev2` Vite build
- Upgrade AWS CDK from v1 to v2