### PR TITLE
fix: post-upgrade api server errors; cors + node 24 callback migration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,4 @@ COPY --from=build /app/packages/models/package.json ${LAMBDA_TASK_ROOT}/packages
 COPY --from=build /app/node_modules ${LAMBDA_TASK_ROOT}/node_modules
 
 # Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
-CMD [ "packages/api/dist/tsc/main.handler" ]  
+CMD [ "packages/api/dist/tsc/main.handler" ]

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.36.0",
-    "@vendia/serverless-express": "^4.4.0",
+    "@codegenie/serverless-express": "^5.0.0-beta.2",
     "cors": "^2.8.5",
     "dynamodb-onetable": "^1.9.0",
     "express": "^4.17.1"

--- a/packages/api/src/main.ts
+++ b/packages/api/src/main.ts
@@ -1,4 +1,4 @@
-import serverlessExpress from "@vendia/serverless-express";
+import serverlessExpress from "@codegenie/serverless-express";
 import express from "express";
 import cors from "cors";
 import { GameModel, PlayerActionsModel, table, ViewModel } from "./models";

--- a/packages/ops/lib/api-stack.ts
+++ b/packages/ops/lib/api-stack.ts
@@ -2,6 +2,7 @@ import * as cdk from "aws-cdk-lib";
 import * as apigateway from "aws-cdk-lib/aws-apigatewayv2";
 import * as apigatewayIntegrations from "aws-cdk-lib/aws-apigatewayv2-integrations";
 import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
+import * as assets from "aws-cdk-lib/aws-ecr-assets";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import { Construct } from "constructs";
 import * as path from "path";
@@ -23,8 +24,10 @@ export class ApiStack extends cdk.Stack {
     });
 
     const lambdaFunction = new lambda.DockerImageFunction(this, "Function", {
+      architecture: lambda.Architecture.ARM_64,
       code: lambda.DockerImageCode.fromImageAsset(path.join(__dirname, "../../.."), {
         exclude: ["packages/ops"],
+        platform: assets.Platform.LINUX_ARM64,
       }),
       environment: {
         DYNAMODB_TABLE_NAME: table.tableName,

--- a/packages/ops/lib/api-stack.ts
+++ b/packages/ops/lib/api-stack.ts
@@ -35,6 +35,12 @@ export class ApiStack extends cdk.Stack {
 
     const api = new apigateway.HttpApi(this, "Api", {
       defaultIntegration: new apigatewayIntegrations.HttpLambdaIntegration("Integration", lambdaFunction),
+      corsPreflight: {
+        allowOrigins: [
+          "https://battles.tomwwright.com",
+          "http://localhost:5173" // vite dev server
+        ]
+      }
     });
   }
 }

--- a/packages/ops/lib/pipeline-stack.ts
+++ b/packages/ops/lib/pipeline-stack.ts
@@ -3,7 +3,7 @@ import * as iam from "aws-cdk-lib/aws-iam";
 import * as pipelines from "aws-cdk-lib/pipelines";
 import * as ssm from "aws-cdk-lib/aws-ssm";
 import { Construct } from "constructs";
-import { ComputeType, LinuxBuildImage } from "aws-cdk-lib/aws-codebuild";
+import { ComputeType, LinuxArmBuildImage } from "aws-cdk-lib/aws-codebuild";
 
 export class PipelineStack extends cdk.Stack {
   public readonly pipeline: pipelines.CodePipeline;
@@ -51,8 +51,8 @@ export class PipelineStack extends cdk.Stack {
       }),
       synthCodeBuildDefaults: {
         buildEnvironment: {
-          buildImage: LinuxBuildImage.fromCodeBuildImageId("aws/codebuild/standard:8.0"),
-          computeType: ComputeType.MEDIUM,
+          buildImage: LinuxArmBuildImage.AMAZON_LINUX_2023_STANDARD_3_0,
+          computeType: ComputeType.LARGE,
         },
         rolePolicy: rolePolicyStatements,
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1018,6 +1018,11 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@codegenie/serverless-express@^5.0.0-beta.2":
+  version "5.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@codegenie/serverless-express/-/serverless-express-5.0.0-beta.2.tgz#616f0168907f39f90a7b209d91490bedbcdf3e02"
+  integrity sha512-NL1BWu+VzOjMiul5hCwIXf720Y7UEvY/7S0KxIw54wAFrGmALlmLITNKynHvaTQALwj0zsyS3KFM+lLLz5+j9A==
+
 "@ctrl/tinycolor@^3.3.4":
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/@ctrl/tinycolor/-/tinycolor-3.6.1.tgz#b6c75a56a1947cc916ea058772d666a2c8932f31"
@@ -3316,11 +3321,6 @@
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz#538b1e103bf8d9864e7b85cc96fa8d6fb6c40777"
   integrity sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==
-
-"@vendia/serverless-express@^4.4.0":
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/@vendia/serverless-express/-/serverless-express-4.4.0.tgz#21d7e4322c6280180afa502fe7d0cfff57fcc758"
-  integrity sha512-WwbInZUKl5Ww/2/uRGU+fpgJzUkilaqFHXafvQilpW2xGryG4pgGymcpLH+z8lDXS5Zg2570tRSOJlUnwbTg9g==
 
 "@vitejs/plugin-react@^4.0.0":
   version "4.7.0"


### PR DESCRIPTION
## Purpose 🎯 

Fix API that has broken after some upgrades

## Context 💭 

- Configure CORS that was missing previously (not sure how it was working from `battles.tomwwright.com` before)
- Update `serverless-express` to v5 to solve lambda init error on Node 24

```
 {
      "errorType": "Runtime.CallbackHandlerDeprecated",
      "errorMessage": "ERROR: AWS Lambda has removed support for callback-based function handlers starting with Node.js 24. You need to modify
   this function to use a supported handler signature to use Node.js 24 or later. For more information see
  https://docs.aws.amazon.com/lambda/latest/dg/nodejs-handler.html.",
      "name": "Runtime.CallbackHandlerDeprecated",
      "stack": [
          "Runtime.CallbackHandlerDeprecated: ERROR: AWS Lambda has removed support for callback-based function handlers starting with Node.js
   24. You need to modify this function to use a supported handler signature to use Node.js 24 or later. For more information see
  https://docs.aws.amazon.com/lambda/latest/dg/nodejs-handler.html.",
          "    at errorOnDeprecatedCallback (file:///var/runtime/index.mjs:613:11)",
          "    at createRuntime (file:///var/runtime/index.mjs:1218:5)",
          "    at async ignition (file:///var/runtime/index.mjs:1633:21)"
      ]
  }
```

- Switch from x86 to ARM to match local development environment