### PR TITLE
fix: only bundle and register BabylonJS Inspector in dev builds

### DIFF
--- a/packages/gamev2/src/ui/BabylonJsProvider.tsx
+++ b/packages/gamev2/src/ui/BabylonJsProvider.tsx
@@ -4,13 +4,11 @@ import { Engine } from '@babylonjs/core/Engines/engine';
 import { Vector3 } from '@babylonjs/core/Maths/math.vector';
 import { Scene } from '@babylonjs/core/scene';
 import { createContext, useContext, useEffect, useRef, useState, type ReactNode } from 'react';
-import { InspectorToken, ShowInspector } from "@babylonjs/inspector";
 
 type BabylonJsContextValue = {
   engine: Engine;
   scene: Scene;
   camera: ArcRotateCamera;
-  inspectorToggle: SceneInspectorToggle
 };
 
 const BabylonJsContext = createContext<BabylonJsContextValue | null>(null);
@@ -41,33 +39,11 @@ function initialiseBabylonJs(canvas: HTMLCanvasElement): BabylonJsContextValue {
 
   window.addEventListener('resize', () => engine.resize());
 
-
-  const inspectorToggle = new SceneInspectorToggle(scene);
-  window.addEventListener("keydown", (ev) => {
-    // Shift+Ctrl+Alt+I
-    if (ev.shiftKey && ev.ctrlKey && ev.altKey && ev.keyCode === 73) {
-      inspectorToggle.toggle();
-    }
-  });
-
-  return { engine, scene, camera, inspectorToggle };
-}
-
-class SceneInspectorToggle {
-  private inspectorToken?: InspectorToken;
-
-  constructor(private readonly scene: Scene) { }
-
-  toggle() {
-    if (this.inspectorToken !== undefined) {
-      console.info("Hiding BabylonJS inspector...")
-      this.inspectorToken.dispose();
-      this.inspectorToken = undefined;
-    } else {
-      console.info("Showing BabylonJS inspector...")
-      this.inspectorToken = ShowInspector(this.scene);
-    }
+  if (import.meta.env.MODE !== 'production') {
+    import('./babylonInspector').then(m => m.attachInspectorToggle(scene));
   }
+
+  return { engine, scene, camera };
 }
 
 /**

--- a/packages/gamev2/src/ui/babylonInspector.ts
+++ b/packages/gamev2/src/ui/babylonInspector.ts
@@ -1,0 +1,19 @@
+import type { Scene } from '@babylonjs/core/scene';
+import type { InspectorToken } from '@babylonjs/inspector';
+
+export function attachInspectorToggle(scene: Scene): void {
+  let token: InspectorToken | undefined;
+  window.addEventListener('keydown', async (ev) => {
+    // Shift+Ctrl+Alt+I
+    if (!(ev.shiftKey && ev.ctrlKey && ev.altKey && ev.keyCode === 73)) return;
+    if (token) {
+      console.info('Hiding BabylonJS inspector...');
+      token.dispose();
+      token = undefined;
+    } else {
+      console.info('Showing BabylonJS inspector...');
+      const { ShowInspector } = await import('@babylonjs/inspector');
+      token = ShowInspector(scene);
+    }
+  });
+}


### PR DESCRIPTION
## Purpose 🎯 

Reduce bundle size by only registering BabylonJS Inspector in development builds. Tree shaking then drops deps from bundle in production.

## Context 💭 

Development build with inspector dependencies (~12mb, ~2.5mb)

```
yarn vite build --mode development
yarn run v1.22.22
$ /home/tomwwright/projects/graph-battles-bundle-inspector-dev/node_modules/.bin/vite build --mode development
vite v6.4.1 building for development...
transforming (83) ../../node_modules/@babylonjs/core/Engines/Extensions/en
✓ 4655 modules transformed.
dist/index.html                                                      0.57 kB │ gzip:     0.34 kB
dist/assets/index-DukIVMqm.css                                       4.79 kB │ gzip:     1.35 kB
...
dist/assets/index-CMvYUNqb.js                                    1,560.40 kB │ gzip:   402.67 kB
dist/assets/babylon.guiEditor-y7YvbIJT.js                        2,744.81 kB │ gzip:   682.25 kB
dist/assets/index-DjPZ4TNP.js                                    6,939.61 kB │ gzip: 1,557.35 kB
```

Production build without inspector dependencies (~6.6mb, ~1.5mb gzip)

```
yarn vite build
yarn run v1.22.22
$ /home/tomwwright/projects/graph-battles-bundle-inspector-dev/node_modules/.bin/vite build
vite v6.4.1 building for production...
✓ 2389 modules transformed.
dist/index.html                                                      0.57 kB │ gzip:     0.34 kB
dist/assets/index-DukIVMqm.css                                       4.79 kB │ gzip:     1.35 kB
...
dist/assets/index-svh9gKGX.js                                    6,636.24 kB │ gzip: 1,478.44 kB
```