### PR TITLE
feat: floating overlay markers for units and territories

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,79 @@
+# AGENTS.md
+
+Operational guide for agents working in this repo. See `README.md` for project blurb and `docs/readme.md` for the in-game manual (rules, territory actions, combat math).
+
+## Project overview
+
+`graph-battles` is a turn-based tactics game played on a graph of territories. Yarn workspaces monorepo of TypeScript packages under `packages/*`. Players issue Actions on Units and Territories; turns resolve simultaneously. Two playable clients exist (v1 Phaser/Mobx, v2 Babylon.js/React) plus a lobby, a domain model package, an API, and CDK infra.
+
+## Toolchain
+
+- Node 24 / Yarn 1.22 (pinned via `.tool-versions`, asdf-compatible)
+- TypeScript 6 across all packages
+- Top-level build: `yarn build` (runs `tsc --build --verbose` over the project references in `tsconfig.json`)
+- Workspaces config in root `package.json` nohoists `@battles/game/**` (v1 Phaser pins ancient React 15 — keep its deps isolated)
+
+## Packages
+
+| Package | Location | Purpose | Notable stack |
+|---|---|---|---|
+| `@battles/models` | `packages/models` | Pure domain model: Game, Map, Territory, Unit, Player, combat, resolver, action types. Shared by all other packages. | TS, mocha+chai tests (`*.test.ts` next to source). No runtime deps. |
+| `@battles/api` | `packages/api` | Express app served via AWS Lambda + DynamoDB (OneTable). Persists games, serves view data. Also publishes a client SDK (`@battles/api/client`). | express, `@codegenie/serverless-express`, `@aws-sdk/client-dynamodb`, `dynamodb-onetable`. Tests in Jest. CLI: `yarn cli`. |
+| `@battles/lobby` | `packages/lobby` | Standalone Vite/React 19 lobby app for picking/creating games. Base path `/lobby/`. | Vite 6, React 19, Fluent UI (loaded via gamev2 — lobby itself is plain CSS modules). |
+| `@battles/game` | `packages/game` | Original game client. **Legacy** Phaser 2 + Mobx 3 + React 15 + Webpack 2. Compiled with old TS then bundled via webpack. Tests in mocha. Has its own `docker-compose.yml` and `nginx.conf` for local dev. | Phaser-CE, Mobx 3, React 15, Webpack 2. |
+| `@battles/gamev2` | `packages/gamev2` | Modern Babylon.js + React 19 game client. Base path `/v2/`. Hex grid renderer, orchestrator pattern syncing model state to scene. Pluggable `GameProvider` (Local / API / Stub). | Vite 6, Babylon.js 9, Fluent UI 9, React 19. |
+| `@battles/ops` | `packages/ops` | AWS CDK 2 app: API stack (Lambda+DynamoDB+HttpApi), App stack (S3+CloudFront+Route53 at `battles.tomwwright.com`), Pipeline stack (CodePipeline from GitHub). | aws-cdk-lib v2. Jest tests in `test/`. |
+
+## Common commands
+
+```sh
+yarn install                            # install all workspaces
+yarn build                              # tsc project-references build (skips game v1 webpack bundle)
+
+# Per-workspace
+yarn workspace @battles/models test     # mocha tests against compiled JS in build/
+yarn workspace @battles/api test        # jest
+yarn workspace @battles/api cli         # tsx src/cli.ts
+yarn workspace @battles/lobby dev       # vite dev server
+yarn workspace @battles/gamev2 dev      # vite dev server
+yarn workspace @battles/gamev2 build    # tsc + vite build
+yarn workspace @battles/game dev        # docker compose up (webpack + nginx)
+yarn workspace @battles/game test       # compile then mocha
+yarn workspace @battles/ops cdk synth   # via "yarn workspace @battles/ops cdk -- <args>"
+```
+
+The CI pipeline (see `packages/ops/lib/pipeline-stack.ts`) runs: `yarn install` → `yarn build` → models test → api test → game bundle+package → gamev2 build+package → lobby build+package → ops cdk synth. Match that order when validating changes locally.
+
+## Architecture notes
+
+- **`@battles/models` is the single source of truth** for game state shape. Game data is versioned (v1, v2 envelope) — `@battles/game` only emits v1, `@battles/lobby` writes a versioned envelope that `@battles/game` reads back. Keep both readers compatible when editing serialization (see recent commits `d157eda`, `6f857f5`).
+- **gamev2 orchestration**: `GameOrchestrator` (in `src/orchestration`) is the bridge between the model and the Babylon scene. Renderers in `src/rendering` (`MapRenderer`, `UnitRenderer`, `HexGridController`, etc.) are scene-only; state lives in `src/state/GameStore.ts`. Providers in `src/providers` abstract persistence (`LocalGameProvider`, `APIGameProvider`, `StubGameProvider`).
+- **Actions are retrieved by `playerId`, not `userId`**. There was a bug here recently (`812bfb9`) — preserve this when touching action lookup.
+- **api `models/` directory** is the OneTable schema (not domain models — those live in `@battles/models`).
+- **Resolver logic** sits in `packages/models/src/resolver.ts` + `territoryActionResolvers.ts`. Spec for a planned refactor lives at `specs/refactor-resolver-logic-and-state.md`.
+
+## Specs
+
+`specs/` contains design docs for in-flight or completed initiatives. Read the relevant one before large changes:
+
+- `aws-cdk-v2.md`, `upgrade-typescript.md` — completed upgrades, useful as history
+- `game-v2-babylonjs.md`, `phase-5-react-ui-panels.md`, `gamev2-mobile-ui-refactor.md`, `gamev2-api-game-provider.md` — gamev2 work
+- `standalone-lobby-package.md`, `lobby-ui-improvements.md` — lobby work
+- `refactor-resolver-logic-and-state.md` — planned, not started
+
+## Tests
+
+- Models and game v1 use **mocha + chai**, compiling first then running against `build/`. The test file pattern is `*.test.ts` colocated with source. Run via `yarn workspace @battles/<pkg> test`.
+- API and ops use **Jest** with `ts-jest`.
+- gamev2 and lobby have no test suite currently — verify changes by running their dev servers.
+
+## Conventions
+
+- Prettier: single quotes, trailing commas (es5), width 120, 2-space tabs. Configured per-package in `package.json`.
+- ESLint configured in api only (`yarn workspace @battles/api lint`).
+- Imports between workspaces use the `@battles/*` package names, not relative paths across packages.
+- Do not commit `*/package.zip` or `cdk.out/` — they are build artifacts.
+
+## Deployment
+
+Hosted at `https://battles.tomwwright.com`. Static apps (game v1 at `/`, gamev2 at `/v2/`, lobby at `/lobby/`) served from S3 via CloudFront. API runs as a container Lambda (`Dockerfile` at repo root) behind API Gateway HTTP API. Everything is provisioned and continuously deployed from `master` via the CodePipeline in `@battles/ops`.

--- a/packages/gamev2/AGENTS.md
+++ b/packages/gamev2/AGENTS.md
@@ -1,0 +1,255 @@
+# AGENTS.md — `@battles/gamev2`
+
+Modern game client. Babylon.js 9 scene + React 19 UI, glued by a `GameOrchestrator`. Served at `/v2/` (Vite `base`). See repo-root `AGENTS.md` for monorepo context and `packages/models` for the domain model.
+
+## Stack
+
+- Vite 6, React 19, TypeScript 6
+- `@babylonjs/core` + `loaders`, `gui`, `inspector`, `materials`, `addons`
+- `@fluentui/react-components` 9 for UI panels
+- Depends on `@battles/models` (domain) and `@battles/api` (REST client + view-data envelope helpers)
+- No test suite — verify via `yarn workspace @battles/gamev2 dev`
+
+Scripts: `dev`, `build` (`tsc && vite build`), `preview`, `package` (zips `dist/` for ops upload).
+
+## Layers
+
+Three concentric layers. Outer layer never touches inner internals — go through the bridge.
+
+```
+React UI (src/ui)
+   ▲ subscribes via useGameStore / dispatches Commands via useDispatch
+   │
+GameOrchestrator (src/orchestration) ─── owns ───▶ GameStore (src/state)
+       │                                                ▲
+       │ routes Commands                                │ listeners + syncers
+       │ to handlers                                    │ self-subscribe via
+       ▼                                                │ narrow ...State slices
+handlers/*.ts ── dispatch(StateChange) ────────────────┘
+                                                        │
+                                                        ▼
+                                          UnitSyncer / TerritorySyncer /
+                                          CameraSyncer ── push ──▶ GameRenderer
+                                                                       │
+                                                                       ▼
+                                                              Babylon Scene
+```
+
+- **`src/state/GameStore.ts`** — pub/sub container for `StoreState`. State changes flow through `dispatch(action: StateChange)` which runs the `reducer`. `GameMap` is mutated in place, so the reducer bumps `mapRevision` whenever an action replaces the map or signals an in-place mutation. React subscribes via `useGameStore(selector)` (wraps `useSyncExternalStore`). Also exposes `trackAnimation(promise)` — adds an `AnimationToken` to `pendingAnimations` for the lifetime of the promise.
+- **`src/state/types.ts`** — owns `Phase` (turn-flow state machine, see below), `Command` (input union), `StateChange` (named mutations consumed by the reducer), and capability interfaces (`Subscribable<T>`, `StateDispatcher`, `AnimationTracker`).
+- **`src/state/reducer.ts`** — pure switch from `StateChange` → next `StoreState`. Every state-shape change has a named variant; the reducer is the only place state shape is mutated.
+- **`src/state/selectors.ts`** — selectors typed against narrow `<S extends ...State>` slices so consumers pass their own minimal state types. Key selectors: `selectCurrentPlayerId`, `selectResolvedCurrentPlayerId` (three-tier fallback used by handlers), `selectNoRunningAnimations`.
+- **`src/orchestration/GameOrchestrator.ts`** — wiring + routing + lifecycle. Builds `HandlerContext`, constructs self-subscribing listeners + syncers, routes `Command`s to handlers via a switch. Owns the concrete `GameStore`; all consumers reference interfaces.
+- **`src/orchestration/HandlerContext.ts`** — service interface passed to handlers: `getState`, `dispatch`, `applyAction`, `advanceResolution`. Keeps handlers free of direct dependencies on `GameStore`, provider, renderer, listener.
+- **`src/orchestration/WaitForTurnResolutionListener.ts`** — self-subscribing listener for the `waiting` phase. Tracks `lastPhase`; on enter starts `provider.waitForTurn`, on exit aborts. Resolved turn flows back via injected `onResolved` callback. Reads via `Subscribable<WaitForTurnResolutionListenerState>` (`{ phase; turn }`).
+- **`src/orchestration/ReplayingListener.ts`** — self-subscribing listener for the `replaying` phase. Drives the `resolveTurn` generator inline (no separate runner class), owns the `AbortController`, the step-gate resolver (`pending`), and the post-replay continuation (`pendingOnComplete`). Detects replay → replay session changes by `state.map` reference inequality. Also exposes `runReplayAndAdvance(resolved, priorTurn)` for the wait-listener callback and `advance(action)` for the `advanceResolution` handler.
+- **`src/orchestration/handlers/`** — one file per command. Each handler is a function `(ctx: HandlerContext, cmd: Cmd<'…'>) => void`. Phase guards live at top of each handler.
+- **`src/orchestration/selection.ts`** — pure selection logic for unit/territory clicks. Returns a `Selection | null` (no longer `Partial<StoreState>`). Consumed by `clickUnit` / `clickTerritory` handlers.
+- **`src/rendering/GameRenderer.ts`** — facade over `SceneRenderer` / `CameraController` / `HexGridController` / `MapRenderer` / `UnitRenderer` / `AssetLoader`. Only rendering API the orchestration layer uses. Scene state lives here; game state does NOT.
+- **Syncers** in `src/orchestration` self-subscribe to the store via narrow `Subscribable<...State>` slices and project state to the renderer:
+  - `UnitSyncer` — diff units on `mapRevision` change. Add/remove/reposition meshes, set status + planned-move lines. When `currentResolution.phase === 'move'` and the unit matches, animates via `animateUnitMove` and registers the promise through `tracker.trackAnimation`; otherwise snaps.
+  - `TerritorySyncer` — repaint hex tile overlays on `mapRevision` or selection change. Base layer = ownership colours (covers `territory-control` resolutions implicitly); selection layer = valid destinations + grass waypoints, or selected territory highlight. Also owns composition delta: when `currentResolution.phase === 'territory-action'` and the territory matches, hands `lastProperties` + `nextProperties` to the renderer for tile-mesh diffing.
+  - `CameraSyncer` — subscribes to `currentResolution`. When non-null, resolves the focus territory and calls `renderer.focusOn`, tracking the in-flight promise so the replay loop's idle gate waits for it.
+
+## GameOrchestrator — flow
+
+`new GameOrchestrator(store, renderer, provider, userId?)` then `await initialise(renderMap)`.
+
+Constructor wires the listeners up front so they observe the very first phase transition. `initialise` order:
+1. `provider.get()` → build `GameMap` from `game.latestMap`.
+2. Resolve `playablePlayerIds` via `resolvePlayablePlayerIds(game, userId, map)` — if `userId` set, only that user's players (mirrors v1 `setFilteredUserIds`); else all players (hot-seat / stub). NOT stored — derived on demand via `selectPlayablePlayerIds(state)`.
+3. Compute `notReadyPlayablePlayerIds`. Initial `phase` = `{ type: 'next-player', currentPlayerId: <first not-ready playable> }` unless all playable already ready, then `{ type: 'waiting', submittedAtTurn: game.turn }`.
+4. Dispatch `init` action. `WaitForTurnResolutionListener` (constructed in the orchestrator ctor) observes the `next-player`/`waiting` transition from the placeholder phase; if the initial real phase is `waiting`, the listener kicks `provider.waitForTurn` on its own — no explicit call from `initialise`.
+5. `renderer.initialise(renderMap, map)` then register input callbacks. Renderer clicks become `click-territory` / `click-unit` commands.
+6. Construct `UnitSyncer` + `TerritorySyncer` + `CameraSyncer`.
+
+### Phase state machine
+
+`Phase` is a discriminated union (`type` discriminator). Per-phase data lives inside the variant — no leaking instance fields on the orchestrator.
+
+| Phase | Data | UI shown | Legal commands |
+|---|---|---|---|
+| `next-player` | `currentPlayerId` | `NextPlayerPopup` | `confirm-next-player`, `set-turn`, click (inspect) |
+| `planning` | `currentPlayerId` | input enabled | `territory-action`, `cancel-move`, `ready-player`, `set-turn`, clicks |
+| `waiting` | `submittedAtTurn` | none | `set-turn` only |
+| `replaying` | `currentPlayerId` (carried) | `ResolutionPanel`, `ActionBar` step controls | `resolve-next`, `skip-resolution`, `set-turn` (aborts) |
+| `victory` | — | `VictoryPopup` | `set-turn` |
+
+`replaying` is plain data — no callable fields. The in-flight `AbortController`, step-gate resolver, and post-replay continuation all live on `ReplayingListener` itself.
+
+### Commands → handlers
+
+All input flows through `dispatch(cmd: Command)`:
+
+```
+dispatch → GameOrchestrator.handle(cmd) → switch → handlers/<command>.ts → ctx.dispatch / ctx.applyAction / ctx.advanceResolution
+```
+
+Each `Command` variant has its own file in `src/orchestration/handlers/`. Handlers receive a `HandlerContext` and the typed command. Phase guards live at the top of each handler — illegal `(phase, command)` pairs early-return rather than throwing (input races during phase transitions are normal — clicks landing while a phase change is in flight shouldn't throw).
+
+| Command | File | Notes |
+|---|---|---|
+| `click-unit` | `clickUnit.ts` | Calls `selectionFromUnitClick`. Inspect-only outside `planning`. |
+| `click-territory` | `clickTerritory.ts` | Calls `selectionFromTerritoryClick`. Click on valid destination → `applyAction({type:'move-units',...})`. |
+| `territory-action` | `territoryAction.ts` | Planning-only. `action: null` cancels pending. |
+| `cancel-move` | `cancelMove.ts` | Planning-only. `destinationId: null` refunds the move. |
+| `confirm-next-player` | `confirmNextPlayer.ts` | `next-player` → `planning`. |
+| `ready-player` | `readyPlayer.ts` | Planning-only. Cycles `selectPlayablePlayerIds(state)`. Last → `waiting` (listener picks up the transition and kicks the poll). |
+| `set-turn` | `setTurn.ts` | Validates range. Past turn → `turn/scrubbed-to-past` (phase becomes `replaying`; listener aborts any current replay and starts a new one). Current turn → `turn/jumped-to-current` (phase becomes `planning`). |
+| `resolve-next` / `skip-resolution` | `advanceResolution.ts` | Replaying-only. Calls `ctx.advanceResolution(...)` which resolves the listener's step gate. |
+
+`HandlerContext` surface (implemented in `GameOrchestrator`):
+- `getState()` — read current `StoreState`.
+- `dispatch(action)` — emit a typed `StateChange` to the reducer.
+- `applyAction(action)` — `map.applyAction(action)`, dispatch `map/mutated`, fire-and-forget `provider.action(currentPlayerId, action)`. Errors logged, not surfaced.
+- `advanceResolution(action)` — resolve the in-flight replay step gate. Delegates to `ReplayingListener.advance`.
+
+### Phase-bound side effects
+
+Each phase that has async lifecycle owns a self-subscribing listener. The listener subscribes to its own narrow slice of `StoreState`, tracks the previous phase, and fires entry/exit work directly — no central registry.
+
+| Phase | Listener | On enter | On exit |
+|---|---|---|---|
+| `waiting` | `WaitForTurnResolutionListener` | allocate `pollAbort`, call `provider.waitForTurn(turn, signal)`, route resolution to `onResolved(resolved, turn)` callback | `pollAbort?.abort()` — aborted poll rejects with `AbortError`, swallowed |
+| `replaying` | `ReplayingListener` | new `AbortController`, `resolveTurn(map)` generator, drive loop inline; on completion fire `pendingOnComplete?(aborted)` | `currentAbort?.abort()` |
+
+`WaitForTurnResolutionListener.onResolved` is wired by the orchestrator to call `ReplayingListener.runReplayAndAdvance(resolved, priorTurn)`. `onError` is handled in the orchestrator (`handleWaitForTurnError`) — drops back to `planning` so the user can retry.
+
+`ReplayingListener` captures its post-replay callback on the listener instance (`pendingOnComplete`) before dispatching `replay/started-post-resolution`. On the entry triggered by that dispatch, the listener consumes the captured callback. Synchronous `notify` ordering makes this safe.
+
+`replaying → replaying` reentry (e.g. `set-turn` scrubbing to a different past turn while mid-replay) is detected by `state.map` reference inequality, not phase type. The reducer constructs a fresh `GameMap` for each turn scrub, so the new map ref signals a new session; in-place mutations during generator iteration keep the same ref. Listener aborts the current replay and starts a new one.
+
+Listeners are constructed BEFORE `initialise`'s `init` dispatch, so the placeholder→real phase transition fires the appropriate entry path automatically.
+
+### Provider AbortSignal
+
+`GameProvider.waitForTurn(currentTurn, signal?)` accepts an optional `AbortSignal`. `APIGameProvider` honours it (cancels both the `get()` await window and the inter-poll sleep), rejecting with `AbortError`. `LocalGameProvider` and `StubGameProvider` ignore the signal — they're synchronous one-shots. Callers should treat `AbortError` as a normal cancellation, not a failure.
+
+### Selection rules
+
+`selectionFromUnitClick` (in `src/orchestration/selection.ts`):
+- No selection / different-owner / non-unit selection → replace with `[unitId]`.
+- Same owner, not in selection → add (multi-select).
+- Same owner, in selection → remove (toggle off).
+- Selecting unit clears `selectedTerritoryId` (mutually exclusive). Host territory derived for overlays, NOT stored.
+- Non-`planning` phase: single-select for inspection only.
+
+`selectionFromTerritoryClick`:
+- Non-`planning` phase: select for inspection.
+- Units selected + click on valid destination → emit `move-units` action effect.
+- Otherwise: select territory, clear units.
+
+### Set-turn (scrubber)
+
+`set-turn` dispatches either `turn/scrubbed-to-past` or `turn/jumped-to-current`. For a past turn it clones `game.data.maps[turn-1]` (so replay mutations don't poison persisted state). `ReplayingListener` aborts any in-flight replay on the phase transition; if both the prior and new phase are `replaying`, the listener detects the new session via `state.map` reference change and restarts. `currentPlayerId` carried via `selectResolvedCurrentPlayerId(state)`.
+
+### Ready-player cycle
+
+`ready-player` increments through `playablePlayerIds`. Last player ready → dispatch `phase/set { type: 'waiting' }`. `WaitForTurnResolutionListener` observes the transition and starts the poll.
+
+### Replay-and-advance
+
+`ReplayingListener.runReplayAndAdvance(resolved, priorTurn)`:
+1. Capture `onComplete = afterPostResolutionReplay` on the listener instance.
+2. Dispatch `replay/started-post-resolution` with `priorTurn` snapshot as the new map (pre-resolve, all pending actions baked in).
+3. The listener's own `onChange` enters replay, runs the generator inline, fires `onComplete(aborted)` on completion.
+4. `afterPostResolutionReplay`: if aborted, bail. Else check `winningPlayers` → dispatch `game/advanced-to-victory` (winners) or `game/advanced-to-next-player` (no winners).
+
+## Resolution loop (`ReplayingListener.driveGenerator`)
+
+Drives the `resolveTurn(map)` generator from `@battles/models`. Generator yields each `Resolution` BEFORE applying its mutation. The next `generator.next()` applies the mutation. The window between gives the loop a chance to publish state and wait.
+
+Per resolution:
+1. Visibility filter — skip if `visibilityMode === 'current-player'` and resolution invisible to `currentPlayerId` (`isUnitVisible` / `isLocationVisible` from `Utils.ts`).
+2. Dispatch `resolution/set` so React UI shows what's about to happen. `CameraSyncer` picks this up and asks the renderer to focus, registering the in-flight focus promise via `trackAnimation`.
+3. `await waitForNoRunningAnimations(signal)` — settles after camera focus completes.
+4. `await waitForAdvance()` — resolved by `ReplayingListener.advance(action)` (invoked via `HandlerContext.advanceResolution`).
+5. On `'skip'`: drain remaining via `generator.next()`, dispatch `resolution/set: null` then `map/mutated` so syncers snap the final state.
+6. Otherwise advance generator (apply mutation), dispatch `map/mutated`. Syncers diff — `UnitSyncer` animates moves matching the current resolution (and tracks the animation), `TerritorySyncer` runs composition deltas, `TerritorySyncer` ownership pass covers `territory-control`.
+7. `await waitForNoRunningAnimations(signal)` — waits for animation tokens to clear, then loops.
+
+Order: `resolution/set` must dispatch BEFORE `map/mutated` so syncers reading the new map see the resolution context.
+
+Animation coverage today: `move` (lerp), `territory-action` (composition delta), `territory-control` (ownership repaint via base layer). `combat` / `food` / `gold` / `add-defend` are not animated.
+
+Camera focus mapping lives in `CameraSyncer.getResolutionFocusTerritory`: `move`/`add-defend` → unit's territory (resolve edge → `territoryAId`); `combat` → location (territory or edge); `food`/`territory-control`/`territory-action` → `territoryId`; `gold` → no focus.
+
+## React UI
+
+`src/main.tsx` provider chain (outer → inner): `GameSessionProvider` → `CursorProvider` → `BabylonJsProvider` → `GameOrchestratorProvider` → `App`.
+
+- **`GameSessionProvider`** — reads URL params (`gameId`, `userId`, `local`). Constructs the right `GameProvider`, fetches map text, parses `RenderMap`, validates against `game.data.maps[0]`. No `gameId` → stub provider with `STUB_MAP_TEXT`. v1 view-data → inline error UI ("cannot be opened in gamev2"). Builds `AssetLoader` from `baseUrl`.
+- **`BabylonJsProvider`** — creates `Engine`, `Scene`, `ArcRotateCamera`. Renders the `<canvas>` absolutely-positioned full-screen behind UI. `Shift+Ctrl+Alt+I` toggles Babylon Inspector (`SceneInspectorToggle`). Uses a ref so StrictMode double-mount doesn't recreate the engine; effect cleanup deliberately does NOT dispose.
+- **`GameOrchestratorProvider`** — constructs `GameRenderer` + `GameStore` + `GameOrchestrator`, calls `initialise(renderMap)`, then publishes `GameStoreContext` and `UserActionDispatchContext`. Both StrictMode mounts await the same `initPromiseRef` — without this the second mount would publish before init resolves, leaving children with `null` `store.game`.
+- **`CursorProvider`** — global `mousemove` cursor pos for tooltip positioning.
+
+### App layout
+
+`src/ui/App.tsx` slots Fluent UI panels into a CSS grid `Frame`:
+- Header: `TurnSelector`
+- LeftColumn: `PlayerLeaderboard`
+- RightColumn: `GameSettingsPanel`, `SelectedSlot` (`ResolutionPanel` + `SelectedInfoPanel`)
+- Footer: `FpsCounter`, `ActionBar`
+- Floating: `NextPlayerPopup`, `VictoryPopup`, `Tooltip`
+
+Components consume state via `useGameStore(selector)` and dispatch via `useDispatch()` (returns `(cmd: Command) => void`). Both throw if used outside `GameOrchestratorProvider`. Components reading the active player should use `useGameStore(selectCurrentPlayerId)` rather than digging into `phase` directly.
+
+## Providers (`src/providers`)
+
+Implementations of `GameProvider`. Selected by `GameSessionProvider` from URL params.
+
+| URL                                   | Provider             | Persistence                          | Resolve                             |
+|---------------------------------------|----------------------|--------------------------------------|--------------------------------------|
+| no `gameId`                           | `createStubProvider` | in-memory `GameData` over stub map   | unsupported (`waitForTurn` throws)   |
+| `?gameId=…&userId=…&local=true`       | `LocalGameProvider`  | `localStorage` key `graph-battles-{gameId}` (shared with lobby) | sync inside `action()` when all ready |
+| `?gameId=…&userId=…`                  | `APIGameProvider`    | REST via `GameApiClient`; per-player pending actions cached in `localStorage` key `graph-battles-v2-actions-{gameId}-{playerId}` | poll `get()` every 10s until `game.turn > currentTurn` |
+
+`GameProvider` interface:
+- `get(): Promise<Game>` — pull state. API impl replays pending local actions on top before returning.
+- `action(playerId, action): Promise<Game>` — record action. API caches to `PlayerActionStorage`; on `ready-player` flushes cache to `api.putPlayerActions`. **Keyed by `playerId`, not `userId`** (matches API's per-player endpoint, mirrors v1 fix `812bfb9`).
+- `getMapText(): Promise<string>` — v2 map text via `unwrapV2MapText` from `@battles/api/client`. Throws if stored view-data is v1.
+- `waitForTurn(currentTurn): Promise<Game>` — Local: read storage once, throw if not advanced. API: poll. Stub: throw.
+
+`LocalGameProvider.action` resolves the turn synchronously (`game.resolveTurn()`) when every player is `ready`, then writes back. So `waitForTurn` for local = read-once.
+
+`APIGameProvider` requires `get()` before `action()` (caches `cachedGameData` for action-time `Game` reconstruction).
+
+## Conventions / gotchas
+
+- Every state-shape mutation goes through `dispatch(action: StateChange)`. The reducer enumerates all permitted transitions — add new variants there. Don't reintroduce a `setState(partial)` escape hatch.
+- `GameMap` is mutated in place. The reducer bumps `mapRevision` for `map/mutated` and any action that replaces the map. Consumers diff on revision, not on map reference.
+- Syncers reach the store via narrow `Subscribable<...State>` slices typed per consumer. Selectors are generic (`<S extends ...State>`) so each consumer's slice satisfies the selectors it calls. Don't widen consumer slices to `StoreState` — it loses the read-tracking property.
+- Consumers depend on capability interfaces (`StateDispatcher`, `AnimationTracker`, `Subscribable<T>`), not on the concrete `GameStore`. Only `GameOrchestrator` imports `GameStore`. Keep it that way.
+- `set-turn` carries `currentPlayerId` across phases via `selectResolvedCurrentPlayerId`. If you add a phase, decide whether to keep this carrying or fall back to `playablePlayerIds[0]`.
+- `playablePlayerIds` is derived (`selectPlayablePlayerIds(state)`), not stored. Don't add a stored copy — keep it computed.
+- Handlers early-return for illegal `(phase, command)` pairs rather than throwing — input races (clicks during transitions) are normal. Don't change to throw without auditing renderer click sources.
+- Adding a new command: add variant to `Command` union in `state/types.ts`, add a file under `handlers/`, export from `handlers/index.ts`, add a `case` to the `handle` switch in `GameOrchestrator`. TS exhaustiveness flags missing cases.
+- Adding a phase with async lifecycle: build a self-subscribing listener (mirror `WaitForTurnResolutionListener` / `ReplayingListener`) — owns its own `AbortController` and internal state, takes a narrow `Subscribable<...State>`, fires entry/exit by tracking `lastPhase`. Don't add side-effect calls in handlers when a phase-tied listener fits.
+- Replay → replay same-type transitions are detected via `state.map` reference inequality, not phase identity. The reducer constructs a fresh `GameMap` on turn-scrub actions. Don't reuse `GameMap` instances across scrubs — would silently break session boundary detection.
+- `Utils.clone`-ed past-turn snapshots are required for replay scrubbing so generator mutations don't poison `game.data.maps[*]`.
+- StrictMode: orchestrator + babylon engine use refs and skip cleanup-dispose. If you add disposal, gate it on production or rework with a single-mount pattern.
+- v1/v2 view-data envelope: lobby writes versioned data; v1 only reads v1. v2 only reads v2 — `unwrapV2MapText` throws `'v1-view-data'` on mismatch and `GameSessionProvider` renders an inline error.
+- `nohoist` for `@battles/game/**` in root `package.json` — gamev2 deps are hoisted normally; don't move gamev2 packages under that nohoist.
+- No tests. Validate UI by running `yarn workspace @battles/gamev2 dev` and exercising the feature.
+- Resolution animation coverage is partial — `combat`/`food`/`gold`/`add-defend` are silent. Extend the relevant syncer (`UnitSyncer` for unit-focused resolutions, `TerritorySyncer` for territory-focused) and the camera focus mapping in `CameraSyncer.getResolutionFocusTerritory` together.
+- `currentPlayerId` initialisation from not-ready players — preserve this on changes (commit `01d7e88`); otherwise refresh-mid-turn lands on the wrong player.
+- Don't commit `dist/`, `package.zip`, or `tsconfig.tsbuildinfo`.
+
+## React↔Babylon integration
+
+There are two distinct kinds of React↔Babylon coupling; pick the right pattern for each:
+
+**Heavyweight resource creation** (Engine, Scene, GameOrchestrator, GameRenderer) — these are expensive to create and must not be double-created under StrictMode's double-mount. Pattern: ref-singleton inside the relevant provider (`contextRef.current == null` guard, no dispose on cleanup). Already in place in `BabylonJsProvider` and `GameOrchestratorProvider`. Don't add disposal logic without a single-mount design.
+
+**Lightweight observable subscriptions** (frame ticks, scene events, mesh events) — cheap to add/remove; the standard React effect add/remove-on-cleanup pattern works perfectly under StrictMode. Use the helpers in `src/ui/hooks/`:
+
+- `useFrameTick(callback)` — registers `callback` on `scene.onBeforeRenderObservable`. Fires every frame. Callback stored in a ref so it always calls the latest closure without re-registering.
+- `useBabylonObservable(observable, callback)` — generic version for any `Observable<T>`.
+
+Both are StrictMode-safe: each mount adds its own observer, removes only that observer on cleanup. No ref-singleton needed.
+
+**React → Babylon game-logic writes** — route through `HandlerContext` (`dispatch`, `applyAction`, `advanceResolution`). Handlers call `renderer.*` via the context; components call `useDispatch()`. Don't reach into the renderer directly from components unless it's purely a read for rendering data.
+
+**Babylon → DOM per-frame (markers)** — `MarkerLayer` uses `useFrameTick` to run a projection loop each frame. It writes `style.transform` and `style.visibility` directly via refs — never through React state. Idle optimisation: the loop compares camera scalars, viewport size, `mapRevision`, and `pendingAnimations.length` against cached last-frame values and bails out early when nothing changed. This cuts per-frame work to ~1 μs when the board is static.
+
+**Rule of thumb**: if the update fires at 60 fps, write to DOM refs directly. If it fires on discrete state changes (game actions, phase transitions), use `useGameStore` selectors.

--- a/packages/gamev2/src/rendering/GameRenderer.ts
+++ b/packages/gamev2/src/rendering/GameRenderer.ts
@@ -1,5 +1,6 @@
 import { ArcRotateCamera } from '@babylonjs/core/Cameras/arcRotateCamera';
 import { Color3 } from '@babylonjs/core/Maths/math.color';
+import { Vector3 } from '@babylonjs/core/Maths/math.vector';
 import { Scene } from '@babylonjs/core/scene';
 import { ID, Values, GameMap } from '@battles/models';
 import { HexCoord, hexCenterTile, hexToTileCoords, tileGridSize } from './HexCoordinates';
@@ -171,6 +172,12 @@ export class GameRenderer {
     if (newMeshes.length > 0) {
       this.sceneRenderer.registerMeshes(newMeshes);
     }
+  }
+
+  getTerritoryWorldPos(id: ID): Vector3 | null {
+    const coord = this.territoryCoordMap.get(id);
+    if (!coord) return null;
+    return this.grid.getWorldPosition(hexCenterTile(coord));
   }
 
   // --- Unit rendering ---

--- a/packages/gamev2/src/rendering/GameRenderer.ts
+++ b/packages/gamev2/src/rendering/GameRenderer.ts
@@ -107,6 +107,7 @@ export class GameRenderer {
 
   onHover(callback: HoverCallback): void {
     this.grid.onHover(callback);
+    this.unitRenderer.onHover(callback);
   }
 
   // --- Camera ---

--- a/packages/gamev2/src/rendering/UnitRenderer.ts
+++ b/packages/gamev2/src/rendering/UnitRenderer.ts
@@ -19,6 +19,7 @@ import { HexCoord, hexCenterTile } from './HexCoordinates';
 import { HexGridController } from './HexGridController';
 import { AssetLoader } from './AssetLoader';
 import type { RenderMap } from '../map/MapParser';
+import type { HoverInfo } from '../state/types';
 
 const UNIT_HEIGHT = 1.2;
 const UNIT_BASE_Y = UNIT_HEIGHT / 2 + 1;
@@ -40,6 +41,7 @@ type UnitState = {
 };
 
 type UnitClickCallback = (unitId: ID) => void;
+type HoverCallback = (hover: HoverInfo) => void;
 type MeshRegistrationCallback = (mesh: AbstractMesh) => void;
 
 /**
@@ -55,6 +57,7 @@ export class UnitRenderer {
   private map: RenderMap | null = null;
   private edgeTerritoryMap = new Map<ID, { territoryA: ID; territoryB: ID }>();
   private clickCallback: UnitClickCallback | null = null;
+  private hoverCallback: HoverCallback | null = null;
   private meshRegistrationCallback: MeshRegistrationCallback | null = null;
 
   constructor(
@@ -81,6 +84,10 @@ export class UnitRenderer {
 
   onUnitClick(callback: UnitClickCallback): void {
     this.clickCallback = callback;
+  }
+
+  onHover(callback: HoverCallback): void {
+    this.hoverCallback = callback;
   }
 
   // --- Unit lifecycle ---
@@ -138,6 +145,18 @@ export class UnitRenderer {
       m.actionManager.registerAction(
         new ExecuteCodeAction(ActionManager.OnPickTrigger, () => {
           this.clickCallback?.(unitId);
+        })
+      );
+      m.actionManager.registerAction(
+        new ExecuteCodeAction(ActionManager.OnPointerOverTrigger, () => {
+          const locationId = this.units.get(unitId)?.locationId;
+          if (!locationId) return;
+          this.hoverCallback?.({ type: 'unit', unitId });
+        })
+      );
+      m.actionManager.registerAction(
+        new ExecuteCodeAction(ActionManager.OnPointerOutTrigger, () => {
+          this.hoverCallback?.(null);
         })
       );
     };

--- a/packages/gamev2/src/rendering/UnitRenderer.ts
+++ b/packages/gamev2/src/rendering/UnitRenderer.ts
@@ -285,6 +285,10 @@ export class UnitRenderer {
     return this.units.has(unitId);
   }
 
+  getMesh(unitId: ID): AbstractMesh | null {
+    return this.units.get(unitId)?.mesh ?? null;
+  }
+
   getUnitIds(): ID[] {
     return Array.from(this.units.keys());
   }

--- a/packages/gamev2/src/state/types.ts
+++ b/packages/gamev2/src/state/types.ts
@@ -42,6 +42,7 @@ export type VisibilityMode = 'all' | 'current-player';
 export type HoverInfo =
   | { type: 'territory'; territoryId: ID; hexCoord: HexCoord }
   | { type: 'edge'; territoryA: ID; territoryB: ID; hexCoord: HexCoord }
+  | { type: 'unit'; unitId: ID }
   | null;
 
 /**

--- a/packages/gamev2/src/state/useDispatch.ts
+++ b/packages/gamev2/src/state/useDispatch.ts
@@ -1,5 +1,4 @@
-import { useContext } from 'react';
-import { DispatchContext } from '../ui/GameOrchestratorProvider';
+import { useGameOrchestrator } from '../ui/GameOrchestratorProvider';
 import type { Dispatch } from './types';
 
 /**
@@ -7,9 +6,5 @@ import type { Dispatch } from './types';
  * flows through this single function as a `Command`.
  */
 export function useDispatch(): Dispatch {
-  const dispatch = useContext(DispatchContext);
-  if (!dispatch) {
-    throw new Error('useDispatch must be used within a GameOrchestratorProvider');
-  }
-  return dispatch;
+  return useGameOrchestrator().dispatch;
 }

--- a/packages/gamev2/src/state/useGameStore.ts
+++ b/packages/gamev2/src/state/useGameStore.ts
@@ -1,5 +1,5 @@
-import { useContext, useSyncExternalStore } from 'react';
-import { GameStoreContext } from '../ui/GameOrchestratorProvider';
+import { useSyncExternalStore } from 'react';
+import { useGameOrchestrator } from '../ui/GameOrchestratorProvider';
 import { StoreState } from './types';
 
 /**
@@ -7,10 +7,7 @@ import { StoreState } from './types';
  * Components call useGameStore(s => s.turnPhase) to subscribe to specific slices.
  */
 export function useGameStore<T>(selector: (state: StoreState) => T): T {
-  const store = useContext(GameStoreContext);
-  if (!store) {
-    throw new Error('useGameStore must be used within a GameOrchestratorProvider');
-  }
+  const { store } = useGameOrchestrator();
 
   return useSyncExternalStore(
     store.subscribe.bind(store),

--- a/packages/gamev2/src/ui/App.tsx
+++ b/packages/gamev2/src/ui/App.tsx
@@ -9,6 +9,7 @@ import { NextPlayerPopup } from './components/NextPlayerPopup';
 import { VictoryPopup } from './components/VictoryPopup';
 import { Tooltip } from './components/Tooltip';
 import { FpsCounter } from './components/FpsCounter';
+import { MarkerLayer } from './components/MarkerLayer';
 
 export function App() {
   return (
@@ -30,6 +31,7 @@ export function App() {
         <FpsCounter />
         <ActionBar />
       </Footer>
+      <MarkerLayer />
       <NextPlayerPopup />
       <VictoryPopup />
       <Tooltip />

--- a/packages/gamev2/src/ui/GameOrchestratorProvider.tsx
+++ b/packages/gamev2/src/ui/GameOrchestratorProvider.tsx
@@ -1,4 +1,4 @@
-import { createContext, useEffect, useRef, useState, type ReactNode } from 'react';
+import { createContext, useContext, useEffect, useRef, useState, type ReactNode } from 'react';
 import { ArcRotateCamera } from '@babylonjs/core/Cameras/arcRotateCamera';
 import { GameStore } from '../state/GameStore';
 import type { Dispatch } from '../state/types';
@@ -9,6 +9,13 @@ import { useGameSession } from './GameSessionProvider';
 
 export const GameStoreContext = createContext<GameStore | null>(null);
 export const DispatchContext = createContext<Dispatch | null>(null);
+export const GameRendererContext = createContext<GameRenderer | null>(null);
+
+export function useGameRenderer(): GameRenderer {
+  const ctx = useContext(GameRendererContext);
+  if (!ctx) throw new Error('useGameRenderer must be used within GameOrchestratorProvider');
+  return ctx;
+}
 
 type GameOrchestratorProviderProps = {
   children: ReactNode;
@@ -23,12 +30,14 @@ export function GameOrchestratorProvider({ children }: GameOrchestratorProviderP
   const { scene, camera } = useBabylonJs();
   const { provider, renderMap, assetLoader, userId } = useGameSession();
   const orchestratorRef = useRef<GameOrchestrator | null>(null);
+  const rendererRef = useRef<GameRenderer | null>(null);
   const initPromiseRef = useRef<Promise<void> | null>(null);
   const [orchestrator, setOrchestrator] = useState<GameOrchestrator | null>(null);
 
   useEffect(() => {
     if (orchestratorRef.current == null) {
       const renderer = new GameRenderer(scene, camera as ArcRotateCamera, assetLoader);
+      rendererRef.current = renderer;
 
       const store = new GameStore({
         game: null!,
@@ -68,7 +77,9 @@ export function GameOrchestratorProvider({ children }: GameOrchestratorProviderP
   return (
     <GameStoreContext.Provider value={orchestrator.store}>
       <DispatchContext.Provider value={orchestrator.dispatch}>
-        {children}
+        <GameRendererContext.Provider value={rendererRef.current}>
+          {children}
+        </GameRendererContext.Provider>
       </DispatchContext.Provider>
     </GameStoreContext.Provider>
   );

--- a/packages/gamev2/src/ui/GameOrchestratorProvider.tsx
+++ b/packages/gamev2/src/ui/GameOrchestratorProvider.tsx
@@ -7,14 +7,22 @@ import { GameRenderer } from '../rendering/GameRenderer';
 import { useBabylonJs } from './BabylonJsProvider';
 import { useGameSession } from './GameSessionProvider';
 
-export const GameStoreContext = createContext<GameStore | null>(null);
-export const DispatchContext = createContext<Dispatch | null>(null);
-export const GameRendererContext = createContext<GameRenderer | null>(null);
+type GameOrchestratorContextValue = {
+  store: GameStore;
+  dispatch: Dispatch;
+  renderer: GameRenderer;
+};
+
+export const GameOrchestratorContext = createContext<GameOrchestratorContextValue | null>(null);
+
+export function useGameOrchestrator(): GameOrchestratorContextValue {
+  const ctx = useContext(GameOrchestratorContext);
+  if (!ctx) throw new Error('useGameOrchestrator must be used within GameOrchestratorProvider');
+  return ctx;
+}
 
 export function useGameRenderer(): GameRenderer {
-  const ctx = useContext(GameRendererContext);
-  if (!ctx) throw new Error('useGameRenderer must be used within GameOrchestratorProvider');
-  return ctx;
+  return useGameOrchestrator().renderer;
 }
 
 type GameOrchestratorProviderProps = {
@@ -23,21 +31,20 @@ type GameOrchestratorProviderProps = {
 
 /**
  * Creates the orchestrator from BabylonJs context + GameSession, initialises it,
- * then provides GameStoreContext and DispatchContext to children.
+ * then provides a single GameOrchestratorContext to children.
  * Uses a ref to ensure only one orchestrator is created even under StrictMode double-mount.
  */
 export function GameOrchestratorProvider({ children }: GameOrchestratorProviderProps) {
   const { scene, camera } = useBabylonJs();
   const { provider, renderMap, assetLoader, userId } = useGameSession();
   const orchestratorRef = useRef<GameOrchestrator | null>(null);
-  const rendererRef = useRef<GameRenderer | null>(null);
+  const ctxValueRef = useRef<GameOrchestratorContextValue | null>(null);
   const initPromiseRef = useRef<Promise<void> | null>(null);
-  const [orchestrator, setOrchestrator] = useState<GameOrchestrator | null>(null);
+  const [ctxValue, setCtxValue] = useState<GameOrchestratorContextValue | null>(null);
 
   useEffect(() => {
     if (orchestratorRef.current == null) {
       const renderer = new GameRenderer(scene, camera as ArcRotateCamera, assetLoader);
-      rendererRef.current = renderer;
 
       const store = new GameStore({
         game: null!,
@@ -56,31 +63,25 @@ export function GameOrchestratorProvider({ children }: GameOrchestratorProviderP
 
       const orch = new GameOrchestrator(store, renderer, provider, userId);
       orchestratorRef.current = orch;
+      ctxValueRef.current = { store, dispatch: orch.dispatch, renderer };
       initPromiseRef.current = orch.initialise(renderMap);
     }
 
     // Both mount runs await the same in-flight init before publishing the
-    // orchestrator — otherwise StrictMode's second mount sees the existing ref
-    // and would publish before init resolves, leaving children with a null
-    // store.game.
+    // context — otherwise StrictMode's second mount sees the existing ref
+    // and would publish before init resolves, leaving children with a null store.
     initPromiseRef.current!.then(() => {
-      setOrchestrator(orchestratorRef.current);
+      setCtxValue(ctxValueRef.current);
     });
 
     // Don't dispose on cleanup — StrictMode remounts effects in dev
   }, [scene, camera, provider, renderMap, userId, assetLoader]);
 
-  if (!orchestrator) {
-    return null;
-  }
+  if (!ctxValue) return null;
 
   return (
-    <GameStoreContext.Provider value={orchestrator.store}>
-      <DispatchContext.Provider value={orchestrator.dispatch}>
-        <GameRendererContext.Provider value={rendererRef.current}>
-          {children}
-        </GameRendererContext.Provider>
-      </DispatchContext.Provider>
-    </GameStoreContext.Provider>
+    <GameOrchestratorContext.Provider value={ctxValue}>
+      {children}
+    </GameOrchestratorContext.Provider>
   );
 }

--- a/packages/gamev2/src/ui/components/ActionBar.tsx
+++ b/packages/gamev2/src/ui/components/ActionBar.tsx
@@ -1,7 +1,7 @@
-import { useContext, useEffect } from 'react';
+import { useEffect } from 'react';
 import { useGameStore } from '../../state/useGameStore';
 import { useDispatch } from '../../state/useDispatch';
-import { GameStoreContext } from '../GameOrchestratorProvider';
+import { useGameOrchestrator } from '../GameOrchestratorProvider';
 import panelStyles from './panels.module.css';
 import styles from './ActionBar.module.css';
 
@@ -10,7 +10,7 @@ export function ActionBar() {
   const phaseType = useGameStore((s) => s.phase.type);
   const autoResolve = useGameStore((s) => s.autoResolve);
   const currentResolution = useGameStore((s) => s.currentResolution);
-  const store = useContext(GameStoreContext);
+  const { store } = useGameOrchestrator();
 
   useEffect(() => {
     if (phaseType !== 'replaying') return;
@@ -37,7 +37,7 @@ export function ActionBar() {
         <div className={styles.container}>
           <button
             className={panelStyles.buttonDanger}
-            onClick={() => store?.dispatch({ type: 'auto-resolve/set', autoResolve: false })}
+            onClick={() => store.dispatch({ type: 'auto-resolve/set', autoResolve: false })}
           >
             Cancel
           </button>
@@ -48,7 +48,7 @@ export function ActionBar() {
       <div className={styles.container}>
         <button
           className={panelStyles.button}
-          onClick={() => store?.dispatch({ type: 'auto-resolve/set', autoResolve: true })}
+          onClick={() => store.dispatch({ type: 'auto-resolve/set', autoResolve: true })}
           disabled={!currentResolution}
         >
           Replay All

--- a/packages/gamev2/src/ui/components/MarkerLayer.module.css
+++ b/packages/gamev2/src/ui/components/MarkerLayer.module.css
@@ -1,0 +1,37 @@
+.pill {
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  padding: 3px 7px;
+  border-radius: 12px;
+  font-family: monospace;
+  font-size: 11px;
+  font-weight: normal;
+  color: white;
+  background-color: rgba(0, 0, 0, 0.6);
+  text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.8);
+  white-space: nowrap;
+  will-change: transform;
+  opacity: 70%;
+  /* visibility toggled imperatively by the frame loop */
+  visibility: hidden;
+}
+
+.chip {
+  display: inline-block;
+  font-size: 16px;
+  font-weight: bold;
+  margin-top: -2px;
+}
+
+.symbol {
+  line-height: 1;
+  font-weight: bold;
+}
+
+.pillSelected {
+  opacity: 1;
+}

--- a/packages/gamev2/src/ui/components/MarkerLayer.tsx
+++ b/packages/gamev2/src/ui/components/MarkerLayer.tsx
@@ -1,0 +1,168 @@
+import { createContext, useContext, useMemo, useRef } from 'react';
+import { Matrix, Vector3 } from '@babylonjs/core';
+import { ArcRotateCamera } from '@babylonjs/core/Cameras/arcRotateCamera';
+import { useGameStore } from '../../state/useGameStore';
+import { useGameRenderer, GameStoreContext } from '../GameOrchestratorProvider';
+import { useBabylonJs } from '../BabylonJsProvider';
+import { useFrameTick } from '../hooks/useFrameTick';
+import { TerritoryMarker } from './TerritoryMarker';
+import { UnitMarker } from './UnitMarker';
+import type { RefObject } from 'react';
+
+export type MarkerEntry = {
+  ref: RefObject<HTMLDivElement | null>;
+  /** Returns the entity's center in world space. The frame tick applies the camera-relative offset. */
+  getCenterWorldPos: () => Vector3 | null;
+  /** World-unit radius of the entity — controls how far the marker sits from center. */
+  offsetAmount: number;
+};
+
+type MarkerRegistry = {
+  register: (id: string, entry: MarkerEntry) => void;
+  unregister: (id: string) => void;
+};
+
+const MarkerRegistryContext = createContext<MarkerRegistry | null>(null);
+
+export function useMarkerRegistry(): MarkerRegistry {
+  const ctx = useContext(MarkerRegistryContext);
+  if (!ctx) throw new Error('useMarkerRegistry must be used within MarkerLayer');
+  return ctx;
+}
+
+const TERRITORY_OFFSET_AMOUNT = 1.35;
+const UNIT_OFFSET_AMOUNT = 0.6;
+
+export function MarkerLayer() {
+  const { scene, engine, camera } = useBabylonJs();
+  const renderer = useGameRenderer();
+  const store = useContext(GameStoreContext);
+
+  // Selectors return strings (primitives) so Object.is gives stable comparison.
+  // Getters like map.territoryIds return new array instances on every call —
+  // returning the array directly would cause useSyncExternalStore to see a
+  // perpetual change and trigger an infinite re-render loop.
+  const territoryIdsKey = useGameStore((s) => s.map?.territoryIds.join(',') ?? '');
+  const unitIdsKey = useGameStore((s) => s.map?.unitIds.join(',') ?? '');
+  const territoryIds = useMemo(() => (territoryIdsKey ? territoryIdsKey.split(',') : []), [territoryIdsKey]);
+  const unitIds = useMemo(() => (unitIdsKey ? unitIdsKey.split(',') : []), [unitIdsKey]);
+
+  const markersRef = useRef<Map<string, MarkerEntry>>(new Map());
+  const registryVersionRef = useRef(0);
+
+  const lastRef = useRef({
+    camX: NaN, camZ: NaN, camR: NaN, camA: NaN, camB: NaN,
+    vpW: NaN, vpH: NaN,
+    mapRevision: -1,
+    registryVersion: -1,
+  });
+
+  // Stable registry object — backed by refs so the context value never changes.
+  const registryRef = useRef<MarkerRegistry>({
+    register(id, entry) {
+      markersRef.current.set(id, entry);
+      registryVersionRef.current++;
+    },
+    unregister(id) {
+      markersRef.current.delete(id);
+      registryVersionRef.current++;
+    },
+  });
+
+  const arcCamera = camera as ArcRotateCamera;
+
+  useFrameTick(() => {
+    if (!store) return;
+    const state = store.getState();
+    const vpW = engine.getRenderWidth();
+    const vpH = engine.getRenderHeight();
+    const mapRevision = state.mapRevision;
+    const registryVersion = registryVersionRef.current;
+    const last = lastRef.current;
+
+    const dirty =
+      state.pendingAnimations.length > 0 ||
+      mapRevision !== last.mapRevision ||
+      registryVersion !== last.registryVersion ||
+      arcCamera.target.x !== last.camX ||
+      arcCamera.target.z !== last.camZ ||
+      arcCamera.radius !== last.camR ||
+      arcCamera.alpha !== last.camA ||
+      arcCamera.beta !== last.camB ||
+      vpW !== last.vpW ||
+      vpH !== last.vpH;
+
+    if (!dirty) return;
+
+    last.camX = arcCamera.target.x;
+    last.camZ = arcCamera.target.z;
+    last.camR = arcCamera.radius;
+    last.camA = arcCamera.alpha;
+    last.camB = arcCamera.beta;
+    last.vpW = vpW;
+    last.vpH = vpH;
+    last.mapRevision = mapRevision;
+    last.registryVersion = registryVersion;
+
+    // Camera-relative right and down unit vectors in world XZ space.
+    // At alpha=0 the working offset is (+X, +Z). As alpha changes we rotate
+    // that base by alpha using the standard XZ rotation matrix columns:
+    //   right = R(alpha) * (1,0) = (cos α,  0, sin α)
+    //   down  = R(alpha) * (0,1) = (-sin α, 0, cos α)
+    // So offset at any alpha = right + down = (cos α − sin α, 0, sin α + cos α),
+    // which correctly equals (1,0,1) at α=0 and rotates with the camera.
+    const alpha = arcCamera.alpha;
+    const camRight = new Vector3( Math.cos(alpha), 0, Math.sin(alpha));
+    const camDown  = new Vector3(-Math.sin(alpha), 0, Math.cos(alpha));
+
+    const xform = scene.getTransformMatrix();
+    const vp = arcCamera.viewport.toGlobal(vpW, vpH);
+    const identity = Matrix.Identity();
+
+    for (const [, entry] of markersRef.current) {
+      const el = entry.ref.current;
+      if (!el) continue;
+
+      const center = entry.getCenterWorldPos();
+      if (!center) {
+        el.style.visibility = 'hidden';
+        continue;
+      }
+
+      const worldPos = center.add(
+        camRight.scale(entry.offsetAmount).add(camDown.scale(entry.offsetAmount))
+      );
+
+      const proj = Vector3.Project(worldPos, identity, xform, vp);
+
+      if (proj.z < 0 || proj.z > 1) {
+        el.style.visibility = 'hidden';
+        continue;
+      }
+
+      el.style.visibility = 'visible';
+      el.style.transform = `translate3d(${proj.x}px, ${proj.y}px, 0)`;
+    }
+  });
+
+  return (
+    <MarkerRegistryContext.Provider value={registryRef.current}>
+      <div
+        style={{
+          position: 'absolute',
+          inset: 0,
+          pointerEvents: 'none',
+          zIndex: 10,
+          overflow: 'hidden',
+        }}
+      >
+        {territoryIds.map((id) => (
+          <TerritoryMarker key={id} id={id} offsetAmount={TERRITORY_OFFSET_AMOUNT} renderer={renderer} />
+        ))}
+        {unitIds.map((id) => (
+          <UnitMarker key={id} id={id} offsetAmount={UNIT_OFFSET_AMOUNT} renderer={renderer} />
+        ))}
+      </div>
+    </MarkerRegistryContext.Provider>
+  );
+}

--- a/packages/gamev2/src/ui/components/MarkerLayer.tsx
+++ b/packages/gamev2/src/ui/components/MarkerLayer.tsx
@@ -2,7 +2,7 @@ import { createContext, useContext, useMemo, useRef } from 'react';
 import { Matrix, Vector3 } from '@babylonjs/core';
 import { ArcRotateCamera } from '@babylonjs/core/Cameras/arcRotateCamera';
 import { useGameStore } from '../../state/useGameStore';
-import { useGameRenderer, GameStoreContext } from '../GameOrchestratorProvider';
+import { useGameRenderer, useGameOrchestrator } from '../GameOrchestratorProvider';
 import { useBabylonJs } from '../BabylonJsProvider';
 import { useFrameTick } from '../hooks/useFrameTick';
 import { TerritoryMarker } from './TerritoryMarker';
@@ -36,7 +36,7 @@ const UNIT_OFFSET_AMOUNT = 0.6;
 export function MarkerLayer() {
   const { scene, engine, camera } = useBabylonJs();
   const renderer = useGameRenderer();
-  const store = useContext(GameStoreContext);
+  const { store } = useGameOrchestrator();
 
   // Selectors return strings (primitives) so Object.is gives stable comparison.
   // Getters like map.territoryIds return new array instances on every call —
@@ -72,7 +72,6 @@ export function MarkerLayer() {
   const arcCamera = camera as ArcRotateCamera;
 
   useFrameTick(() => {
-    if (!store) return;
     const state = store.getState();
     const vpW = engine.getRenderWidth();
     const vpH = engine.getRenderHeight();

--- a/packages/gamev2/src/ui/components/TerritoryMarker.tsx
+++ b/packages/gamev2/src/ui/components/TerritoryMarker.tsx
@@ -1,0 +1,58 @@
+import { useRef } from 'react';
+import { useGameStore } from '../../state/useGameStore';
+import { selectCurrentPlayerId } from '../../state/selectors';
+import { isLocationVisible } from '../../orchestration/Utils';
+import { useMarkerRegistration } from '../hooks/useMarkerRegistration';
+import type { GameRenderer } from '../../rendering/GameRenderer';
+import styles from './MarkerLayer.module.css';
+import { colourToCss, playerShape } from './markerHelpers';
+
+type Props = {
+  id: string;
+  offsetAmount: number;
+  renderer: GameRenderer;
+};
+
+export function TerritoryMarker({ id, offsetAmount, renderer }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  const playerId = useGameStore((s) => s.map?.territory(id)?.data.playerId ?? null);
+  const playerIndex = useGameStore((s) => {
+    if (!s.map) return -1;
+    const idx = s.map.playerIds.indexOf(s.map.territory(id)?.data.playerId ?? '');
+    return idx >= 0 ? idx : -1;
+  });
+  const playerColour = useGameStore((s) => {
+    if (!s.map || !playerId) return null;
+    return s.map.player(playerId)?.data.colour ?? null;
+  });
+  const territory = useGameStore((s) => {
+    if (!s.map) return null;
+    return s.map.territory(id);
+  });
+
+  const hasAction = useGameStore((s) => {
+    const currentPlayerId = selectCurrentPlayerId(s);
+    if (!currentPlayerId) return false;
+    if (s.visibilityMode === 'current-player' && !isLocationVisible(s.map, currentPlayerId, id)) return false;
+    return territory?.currentAction != null;
+  });
+  const isSelected = useGameStore((s) => s.selectedTerritoryId === id);
+
+  useMarkerRegistration(id, ref, () => renderer.getTerritoryWorldPos(id), offsetAmount);
+
+  const shape = playerIndex >= 0 ? playerShape(playerIndex) : '○';
+  const color = playerColour != null ? colourToCss(playerColour) : '#888';
+
+  return (
+    <div ref={ref} className={`${styles.pill}${isSelected ? ` ${styles.pillSelected}` : ''}`}>
+      <span className={styles.chip} style={{ color }}>
+        {shape}{" "}
+      </span>
+      Territory {territory?.data.id}{" "}
+      <span className={styles.symbol}>
+        {hasAction && "[A]"}
+      </span>
+    </div>
+  );
+}

--- a/packages/gamev2/src/ui/components/Tooltip.tsx
+++ b/packages/gamev2/src/ui/components/Tooltip.tsx
@@ -10,7 +10,10 @@ export function Tooltip() {
   if (!hover) return null;
 
   let text: string;
-  if (hover.type === 'territory') {
+  if (hover.type === 'unit') {
+    const unit = map.unit(hover.unitId);
+    text = `Unit ${hover.unitId}${unit ? ` (${unit.data.statuses.length > 0 ? unit.data.statuses.join(', ') : 'no statuses'})` : ''}`;
+  } else if (hover.type === 'territory') {
     const territory = map.territory(hover.territoryId);
     const food = territory ? ` (food ${territory.data.food})` : '';
     text = `Territory ${hover.territoryId}${food}`;

--- a/packages/gamev2/src/ui/components/UnitMarker.tsx
+++ b/packages/gamev2/src/ui/components/UnitMarker.tsx
@@ -1,0 +1,62 @@
+import { useRef } from 'react';
+import { Values } from '@battles/models';
+import { useGameStore } from '../../state/useGameStore';
+import { selectCurrentPlayerId } from '../../state/selectors';
+import { isUnitVisible } from '../../orchestration/Utils';
+import { useMarkerRegistration } from '../hooks/useMarkerRegistration';
+import type { GameRenderer } from '../../rendering/GameRenderer';
+import styles from './MarkerLayer.module.css';
+import { colourToCss, playerShape } from './markerHelpers';
+
+type Props = {
+  id: string;
+  offsetAmount: number;
+  renderer: GameRenderer;
+};
+
+export function UnitMarker({ id, offsetAmount, renderer }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  const playerId = useGameStore((s) => s.map?.unit(id)?.data.playerId ?? null);
+  const playerIndex = useGameStore((s) => {
+    if (!s.map) return -1;
+    const pid = s.map.unit(id)?.data.playerId ?? '';
+    const idx = s.map.playerIds.indexOf(pid);
+    return idx >= 0 ? idx : -1;
+  });
+  const playerColour = useGameStore((s) => {
+    if (!s.map || !playerId) return null;
+    return s.map.player(playerId)?.data.colour ?? null;
+  });
+  const isVisible = useGameStore((s) => {
+    if (!s.map) return false;
+    if (s.visibilityMode === 'all') return true;
+    const currentPlayerId = selectCurrentPlayerId(s);
+    if (!currentPlayerId) return false;
+    return isUnitVisible(s.map, currentPlayerId, id);
+  });
+  const unit = useGameStore((s) => s.map?.unit(id));
+  const isMoving = useGameStore((s) => unit?.destinationId != null);
+  const isDefending = useGameStore((s) => unit?.data.statuses.includes(Values.Status.DEFEND) ?? false);
+  const isStarving = useGameStore((s) => unit?.data.statuses.includes(Values.Status.STARVE) ?? false);
+  const isSelected = useGameStore((s) => s.selectedUnitIds.includes(id));
+
+  useMarkerRegistration(id, ref, () => renderer.getUnitRenderer().getMesh(id)?.getAbsolutePosition() ?? null, offsetAmount);
+
+  if (!isVisible) return null;
+
+  const shape = playerIndex >= 0 ? playerShape(playerIndex) : '○';
+  const color = playerColour != null ? colourToCss(playerColour) : '#888';
+
+  return (
+    <div ref={ref} className={`${styles.pill}${isSelected ? ` ${styles.pillSelected}` : ''}`}>
+      <span className={styles.chip} style={{ color }}>
+        {shape}
+      </span>
+      Unit {unit?.data.id}{" "}
+      {isMoving && <span className={styles.symbol}>[M]</span>}
+      {isDefending && <span className={styles.symbol}>[D]</span>}
+      {isStarving && <span className={styles.symbol}>[S]</span>}
+    </div>
+  );
+}

--- a/packages/gamev2/src/ui/components/markerHelpers.ts
+++ b/packages/gamev2/src/ui/components/markerHelpers.ts
@@ -1,0 +1,11 @@
+// Unicode glyphs — one per player slot, colour set via CSS `color`
+const PLAYER_SHAPES = ['●', '■', '▲', '◆'];
+
+export function playerShape(playerIndex: number): string {
+  return PLAYER_SHAPES[playerIndex % PLAYER_SHAPES.length];
+}
+
+/** Convert a Values.Colour (hex number) to a CSS colour string. */
+export function colourToCss(colour: number): string {
+  return `#${colour.toString(16).padStart(6, '0')}`;
+}

--- a/packages/gamev2/src/ui/hooks/useBabylonObservable.ts
+++ b/packages/gamev2/src/ui/hooks/useBabylonObservable.ts
@@ -1,0 +1,14 @@
+import { Observable } from '@babylonjs/core';
+import { useEffect, useRef } from 'react';
+
+export function useBabylonObservable<T>(observable: Observable<T>, callback: (value: T) => void): void {
+  const cbRef = useRef(callback);
+  cbRef.current = callback;
+
+  useEffect(() => {
+    const obs = observable.add((v) => cbRef.current(v));
+    return () => {
+      observable.remove(obs);
+    };
+  }, [observable]);
+}

--- a/packages/gamev2/src/ui/hooks/useFrameTick.ts
+++ b/packages/gamev2/src/ui/hooks/useFrameTick.ts
@@ -1,0 +1,15 @@
+import { useEffect, useRef } from 'react';
+import { useBabylonJs } from '../BabylonJsProvider';
+
+export function useFrameTick(callback: () => void): void {
+  const { scene } = useBabylonJs();
+  const cbRef = useRef(callback);
+  cbRef.current = callback;
+
+  useEffect(() => {
+    const obs = scene.onBeforeRenderObservable.add(() => cbRef.current());
+    return () => {
+      scene.onBeforeRenderObservable.remove(obs);
+    };
+  }, [scene]);
+}

--- a/packages/gamev2/src/ui/hooks/useMarkerRegistration.ts
+++ b/packages/gamev2/src/ui/hooks/useMarkerRegistration.ts
@@ -1,0 +1,19 @@
+import { useEffect, useRef, type RefObject } from 'react';
+import { Vector3 } from '@babylonjs/core';
+import { useMarkerRegistry } from '../components/MarkerLayer';
+
+export function useMarkerRegistration(
+  id: string,
+  ref: RefObject<HTMLDivElement | null>,
+  getCenterWorldPos: () => Vector3 | null,
+  offsetAmount: number,
+): void {
+  const registry = useMarkerRegistry();
+  const getCenterRef = useRef(getCenterWorldPos);
+  getCenterRef.current = getCenterWorldPos;
+
+  useEffect(() => {
+    registry.register(id, { ref, getCenterWorldPos: () => getCenterRef.current(), offsetAmount });
+    return () => registry.unregister(id);
+  }, [id, registry, offsetAmount]);
+}

--- a/specs/react-ui-markers.md
+++ b/specs/react-ui-markers.md
@@ -1,0 +1,476 @@
+# React UI Markers
+
+## Goal
+
+Render screen-space status markers anchored to every territory and every unit in the gamev2 client. Markers display at-a-glance information (owner color, planned action, unit statuses) so players can read board state without selecting entities.
+
+This work also formalises a small set of React↔Babylon integration utilities so the per-frame DOM updates required by markers (and any future per-frame UI) follow a consistent, StrictMode-safe pattern.
+
+## Scope
+
+In scope:
+
+- `MarkerLayer` React component with one marker per territory and one per unit.
+- Per-frame world→screen projection driving each marker's CSS `transform`, decoupled from React state.
+- Idle optimisation: skip projection entirely when neither camera nor any tracked animation has moved since the last tick.
+- Content rendering (color chip, ASCII status symbols) driven by store subscriptions.
+- Visibility filter honouring `visibilityMode === 'current-player'`.
+- Reusable `useFrameTick` / `useBabylonObservable` hooks for Babylon observable subscriptions.
+- Renderer accessors needed to read entity world positions / meshes.
+- Short documentation update in `packages/gamev2/AGENTS.md` recording the integration pattern.
+
+Out of scope:
+
+- Retrofitting the existing cursor tooltip (different anchoring problem; single component; no performance pressure).
+- Heavier refactor of `BabylonJsProvider` / `GameOrchestratorProvider` (current ref-singleton pattern remains correct for heavyweight resources).
+- Animations on markers themselves (color fades, scale punches, etc.). Defer.
+- Marker pointer interactivity (clicking a marker to select). Defer; markers are `pointer-events: none`.
+
+## Visual design
+
+Each marker is a rounded "pill" styled similarly to the existing tooltip:
+
+```
+┌─────────────────┐
+│ [chip]  M  D    │
+└─────────────────┘
+```
+
+Left to right inside the pill:
+
+1. **Control marker** — a small filled shape (square or circle) in the player's color. Shape varies by player so the encoding is not color-only (accessibility). Neutral / unowned territories render a grey hollow chip.
+2. **Status symbols** — zero or more single-character ASCII glyphs.
+
+Marker anchoring: positioned so the top-left corner of the pill aligns with the bottom-right corner of the entity's projected world anchor (see Positioning).
+
+Styling cues from existing `Tooltip`:
+
+- `padding: 4px 8px`
+- `borderRadius: 12px` (pill)
+- `fontFamily: monospace`
+- `fontSize: 12`
+- `color: white`
+- `backgroundColor: rgba(0, 0, 0, 0.6)`
+- `textShadow: 1px 1px 2px rgba(0,0,0,0.8)`
+- `pointerEvents: none`
+- `zIndex: 10` (below the cursor tooltip at `zIndex: 20`)
+- `whiteSpace: nowrap`
+
+### Content rules
+
+**Unit marker**
+
+| Condition | Symbol |
+|---|---|
+| `unit.data.destinationId != null` | `M` |
+| Status `DEFEND` present | `D` |
+| Status `STARVE` present | `S` |
+
+Symbols stack horizontally in the listed order. Color chip uses the unit's owning player's color.
+
+**Territory marker**
+
+| Condition | Symbol |
+|---|---|
+| Player has a planned territory action on this territory | `A` |
+
+Color chip uses `territory.playerId`'s color, or neutral grey when `null`.
+
+### Player shapes
+
+Map `Values.Colour` (or player index) to a fixed shape so the encoding survives color-blindness:
+
+| Player index | Shape |
+|---|---|
+| 0 | filled circle |
+| 1 | filled square |
+| 2 | filled triangle |
+| 3 | filled diamond |
+
+Implementation: render the chip as an inline SVG or unicode glyph (`●`, `■`, `▲`, `◆`) styled via `color` to match the player's color. Final choice deferred to first implementation pass; either is workable.
+
+## Visibility rules
+
+| Marker type | When shown |
+|---|---|
+| Territory marker | Always shown. Player ownership is not fog-of-war'd. |
+| Territory `A` symbol | Only when `isLocationVisible(currentPlayer, territoryId)`. |
+| Unit marker | Only when `isUnitVisible(currentPlayer, unitId)`. |
+
+When `visibilityMode === 'all'` (hot-seat), all markers and symbols are unconditionally shown.
+
+The "current player" used for visibility tests is `selectResolvedCurrentPlayerId(state)`.
+
+## Positioning
+
+### Bottom-right anchor with zoom-aware offset
+
+Each marker is anchored at the projected screen position of a world-space offset point relative to the entity:
+
+```
+anchorWorld = entityCenterWorld + offsetVector
+```
+
+Where `offsetVector` is roughly the entity's right-front corner in world units:
+
+- Territory: `(+1.5, 0, +1.5)` (hex radius scale)
+- Unit: `(+0.6, 0, +0.6)` (unit half-width scale)
+
+`Vector3.Project` is applied to `anchorWorld`. The resulting `(x, y)` is set as `transform: translate3d(x, y, 0)` on the marker element's top-left corner.
+
+Why this scales naturally with zoom: when the camera zooms in, the world-space offset projects to a larger screen distance, so the marker drifts further from the entity center. Zoomed out, the offset projects small and the marker hugs the entity. No manual zoom factor or DPI scaling needed beyond honouring `engine.getHardwareScalingLevel()` when going from canvas pixels to CSS pixels.
+
+### Position sources
+
+| Marker type | World position function |
+|---|---|
+| Territory | `grid.getWorldPosition(hexCenterTile(coord))` — static; precomputed and cached. |
+| Unit | `mesh.getAbsolutePosition()` — read each frame so Babylon's animation system (move lerps, arrange tweens) drives marker motion automatically. |
+
+### Off-screen culling
+
+For each marker per frame, after projection:
+
+- If `proj.z < 0` or `proj.z > 1`: marker is behind the camera or beyond the far plane. Set `style.visibility = 'hidden'`.
+- Otherwise: set `style.visibility = 'visible'` and write the transform.
+
+`visibility: hidden` keeps layout costs lower than re-mounting on the fence between frames. Optionally widen to `display: none` if profiling shows paint cost dominating.
+
+### HiDPI / hardware scaling
+
+`Vector3.Project` returns coordinates in render-target pixels. The canvas CSS size may differ from the render target by `engine.getHardwareScalingLevel()`. Convert to CSS pixels by dividing the projected `x` and `y` by `hardwareScalingLevel * devicePixelRatio` (exact math to be verified against actual canvas layout during implementation).
+
+## Render-vs-React split
+
+Each marker has two independent update channels into the same DOM node:
+
+| Concern | Owner | Update trigger | Mechanism |
+|---|---|---|---|
+| Position (`style.transform`) | Babylon frame loop | `onBeforeRenderObservable` (60 fps) | Direct DOM write via `ref` |
+| Visibility cull (`style.visibility`) | Babylon frame loop | `onBeforeRenderObservable` (60 fps) | Direct DOM write via `ref` |
+| Existence (mount/unmount) | React | Territory/unit list change | Keyed list in `MarkerLayer` |
+| Color chip | React | Owner change | `useGameStore` selector |
+| Shape | React | Owner change | `useGameStore` selector |
+| Status symbols (`M`/`D`/`S`/`A`) | React | Status / action / destination change | `useGameStore` selectors per flag |
+| Visibility filter (fog of war) | React | Visibility change | Selector returning `null` causes marker to render nothing |
+
+The two channels touch different DOM properties (`transform`/`visibility` vs subtree content) so they do not contend. Babylon writes inline styles directly; React owns the React tree.
+
+## Performance analysis
+
+### Baseline
+
+Realistic upper bound: ~30 territories, ~30 units → ~60 markers.
+
+### Per-frame projection
+
+- `Vector3.Project`: a few hundred ns per call on modern hardware.
+- 60 markers × 60 fps = 3,600 projections/s ≈ **~30 μs/frame**.
+- Style writes (compositor-only `transform`): 60 × ~1 μs = **~60 μs/frame**.
+- Total **~100 μs/frame**, or ~0.6% of a 16.6 ms budget. Headroom to 200+ markers before this dominates.
+
+### React reconcile
+
+The risk is in React, not projection. Mitigations:
+
+- Position **never** stored in React state. No `setState` per frame.
+- Content selectors return primitives (`playerId`, `boolean` flags). `useSyncExternalStore` uses `Object.is` to skip re-renders when primitives don't change.
+- Each dispatch re-evaluates every marker's selector (cheap), but only markers whose underlying primitive actually changed re-render.
+- Re-rendered tree is small (one `<div>`, one chip, up to 3 `<span>`s). Reconcile cost is negligible.
+
+### Subscription model
+
+```ts
+useGameStore(s => s.map.unit(id)?.data.destinationId != null);     // boolean
+useGameStore(s => s.map.unit(id)?.data.statuses.includes(DEFEND)); // boolean
+useGameStore(s => s.map.unit(id)?.data.statuses.includes(STARVE)); // boolean
+useGameStore(s => s.map.unit(id)?.data.playerId ?? null);          // ID | null
+useGameStore(s => isUnitVisible(s.map, currentPlayer, id));        // boolean
+```
+
+Selectors must not allocate new arrays / objects — return primitives only.
+
+### Idle optimisation
+
+Skip the entire projection loop when the scene is visually static — there is nothing to reproject. The marker layer maintains a small bit of cached state between frames and bails out early when nothing has changed.
+
+**Dirty signal sources**
+
+| Source | What we read | When it changes |
+|---|---|---|
+| Camera | `camera.target.x`, `camera.target.z`, `camera.radius`, `camera.alpha`, `camera.beta` | User pan/zoom/rotate, programmatic `focusOn` animation, zoom cycle animation |
+| Engine viewport | `engine.getRenderWidth()`, `engine.getRenderHeight()` | Window resize |
+| Animation tracker | `store.getState().pendingAnimations.length > 0` | Unit move lerps, arrange tweens, camera focus, composition deltas |
+| Marker registry version | `registryVersion` counter bumped on `register` / `unregister` | Marker added or removed (mount/unmount) |
+
+**Algorithm per frame**
+
+```ts
+const cam = { x: camera.target.x, z: camera.target.z, r: camera.radius, a: camera.alpha, b: camera.beta };
+const vp  = { w: engine.getRenderWidth(), h: engine.getRenderHeight() };
+const hasAnims = store.getState().pendingAnimations.length > 0;
+
+const dirty =
+  hasAnims ||
+  registryVersion !== lastRegistryVersion ||
+  cam.x !== last.cam.x || cam.z !== last.cam.z ||
+  cam.r !== last.cam.r || cam.a !== last.cam.a || cam.b !== last.cam.b ||
+  vp.w !== last.vp.w || vp.h !== last.vp.h;
+
+if (!dirty) return;
+
+// project all markers, write transforms, update cull state
+projectAll();
+
+last.cam = cam;
+last.vp = vp;
+lastRegistryVersion = registryVersion;
+```
+
+**Why this is sufficient**
+
+- Camera fields cover every way the projection matrix changes (pan, zoom, rotate). `ArcRotateCamera` derives its view matrix from these scalars.
+- `pendingAnimations.length > 0` forces continued projection while any unit/camera/composition animation is in flight, even if the camera itself is momentarily stationary mid-animation (the *unit* anchor world position is changing).
+- Marker registry version handles mount/unmount races where a new marker registers between frames and needs a first paint.
+- Viewport size covers `window resize` (canvas dimensions change → projection viewport changes).
+
+**First-frame and force-dirty**
+
+- Initialise `last.*` to sentinel values (`NaN` or `-1`) so the first frame is always considered dirty.
+- Expose `MarkerLayer.invalidate()` as an escape hatch on the registry context. Markers can call it when their content changes in a way that affects positioning (currently none — content swaps don't move the pill, so probably unused in practice). Reserved for future use.
+
+**Subscribing to `pendingAnimations`**
+
+`MarkerLayer` doesn't need a React subscription to `pendingAnimations` — the frame tick reads it directly from `store.getState()`. The store is a stable reference; no React re-renders involved. Read happens once per tick (cheap object access), not per marker.
+
+**Cost when idle**
+
+- 5 scalar reads from `camera`, 2 from `engine`, 1 from `store`.
+- 7 numeric comparisons + 1 length check.
+- Total well under 1 μs/frame. Effectively zero CPU while the board is static.
+
+**Cost when active**
+
+Same as the non-optimised case (~100 μs/frame for 60 markers).
+
+**Correctness guarantees**
+
+- Unit `setUnitPosition` (snap, non-animated) is always wrapped by `arrangeLocation` which mutates `mesh.position` directly. This happens during dispatched state changes — `pendingAnimations` won't be set. To cover this case, **also dirty on `mapRevision` change**: subscribe to the store with a narrow selector that bumps a counter, fold into the dirty check. This catches any imperative mesh mutation triggered by `map/mutated`.
+
+Updated dirty check:
+
+```ts
+const dirty =
+  hasAnims ||
+  mapRevision !== last.mapRevision ||
+  registryVersion !== lastRegistryVersion ||
+  /* camera + viewport diffs */;
+```
+
+`mapRevision` already bumps once per `map/mutated`; a snap-arrange immediately after is covered because the bump happens before the frame fires.
+
+**Validation**
+
+- With dev tools open and `console.log` in the projection loop, confirm logs cease ~1 frame after panning stops.
+- Confirm logs resume the frame a unit move begins (camera idle + animation in flight).
+- Confirm logs fire on `map/mutated` even when no animation is pending (composition snap case).
+
+**Defer (still future)**
+
+- Per-marker dirty tracking (only reproject markers whose anchor or visibility actually changed). Not justified at current scale; gates only ~100 μs of total work.
+
+### Validation
+
+- Run `yarn workspace @battles/gamev2 dev` with a populated game (multiple players, ≥20 units).
+- Watch `FpsCounter` during steady-state, replay (rapid `map/mutated` + animations), and camera focus animations.
+- Chrome DevTools Performance profile: confirm no React reconcile spikes during steady state; confirm per-frame budget under ~1 ms for marker work.
+
+## React↔Babylon integration utilities
+
+### Current touchpoints
+
+| Touchpoint | Direction | Dedupe mechanism |
+|---|---|---|
+| `BabylonJsProvider` engine/scene/camera creation | Heavyweight resource | `contextRef` singleton; no dispose on cleanup |
+| `GameOrchestratorProvider` init | One-shot async | `initPromiseRef` shared across StrictMode mounts |
+| Renderer hover/click callbacks | Babylon → React | Set once on init |
+| `HandlerContext.dispatch / applyAction` | React → Babylon (via orchestrator) | Already centralised |
+| `CameraSyncer` focus | React (store) → Babylon (async) | `trackAnimation` tokens |
+| Animation lifecycle | Babylon → store | `trackAnimation` tokens |
+| Marker projection (new) | Babylon → DOM per frame | Needs a hook (see below) |
+
+### Pattern
+
+There are two distinct kinds of integration:
+
+- **Heavyweight resource creation** (engine, orchestrator, renderer): needs a ref-singleton pattern in the relevant provider so StrictMode's double-mount doesn't double-construct. Already in place. Leave alone.
+- **Lightweight observer subscriptions** (frame ticks, scene events, mesh events): cheap to add/remove; the pair-with-cleanup React effect idiom works perfectly under StrictMode. Currently reinvented per usage. Formalise.
+
+### New hooks
+
+Add `packages/gamev2/src/ui/hooks/useFrameTick.ts`:
+
+```ts
+import { useEffect, useRef } from 'react';
+import { useBabylonJs } from '../BabylonJsProvider';
+
+export function useFrameTick(callback: () => void): void {
+  const { scene } = useBabylonJs();
+  const cbRef = useRef(callback);
+  cbRef.current = callback;
+  useEffect(() => {
+    const obs = scene.onBeforeRenderObservable.add(() => cbRef.current());
+    return () => {
+      scene.onBeforeRenderObservable.remove(obs);
+    };
+  }, [scene]);
+}
+```
+
+Add `packages/gamev2/src/ui/hooks/useBabylonObservable.ts`:
+
+```ts
+import { Observable } from '@babylonjs/core';
+import { useEffect, useRef } from 'react';
+
+export function useBabylonObservable<T>(
+  observable: Observable<T>,
+  callback: (value: T) => void
+): void {
+  const cbRef = useRef(callback);
+  cbRef.current = callback;
+  useEffect(() => {
+    const obs = observable.add((v) => cbRef.current(v));
+    return () => {
+      observable.remove(obs);
+    };
+  }, [observable]);
+}
+```
+
+Both hooks are StrictMode-safe by construction: each mount adds its own observer and removes only that observer on cleanup.
+
+### What does *not* change
+
+- `BabylonJsProvider`'s ref-singleton: correct for engine creation cost.
+- `GameOrchestratorProvider`'s `initPromiseRef`: correct for one-shot async init.
+- `HandlerContext` for React→Babylon imperative writes: already centralised.
+- Renderer callback registration (`onTerritoryClick`, etc.): fine as one-shot wiring.
+
+### Documentation
+
+Add a short "React↔Babylon integration" section to `packages/gamev2/AGENTS.md` recording:
+
+- Heavyweight resources → ref-singleton inside provider.
+- Lightweight observer subs → `useFrameTick` / `useBabylonObservable`.
+- React → Babylon game-logic writes → through `HandlerContext`.
+- Babylon → DOM per-frame writes (markers) → direct ref writes inside `useFrameTick`, never React state.
+
+## Renderer accessors
+
+`GameRenderer` needs to expose two read-only lookups for the marker layer:
+
+```ts
+class GameRenderer {
+  getTerritoryWorldPos(id: ID): Vector3 | null;  // territory center in world space
+  getUnitMesh(id: ID): AbstractMesh | null;       // for getAbsolutePosition() each frame
+}
+```
+
+Implementation:
+
+- `getTerritoryWorldPos`: existing logic already lives in private `unitRenderer.territoryCenterPosition`. Lift up to the facade or duplicate as needed.
+- `getUnitMesh`: expose via `unitRenderer.getMesh(id)` returning `this.units.get(id)?.mesh ?? null`. Currently `units` is private; add a narrow getter.
+
+## Component decomposition
+
+### New files
+
+| File | Responsibility |
+|---|---|
+| `src/ui/hooks/useFrameTick.ts` | Subscribe a callback to `scene.onBeforeRenderObservable`. |
+| `src/ui/hooks/useBabylonObservable.ts` | Generic Babylon `Observable` subscription. |
+| `src/ui/components/MarkerLayer.tsx` | Top-level marker overlay; iterates ids; runs projection loop. |
+| `src/ui/components/MarkerLayer.module.css` | Pill, chip, symbol styles. |
+| `src/ui/components/TerritoryMarker.tsx` | Per-territory marker content + position registration. |
+| `src/ui/components/UnitMarker.tsx` | Per-unit marker content + position registration. |
+
+### MarkerLayer responsibilities
+
+- Render absolute-positioned overlay div above the canvas, below the cursor tooltip.
+- Iterate `selectAllTerritoryIds(state)` and (visibility-filtered) `selectAllUnitIds(state)`.
+- Provide a context (`MarkerRegistryContext`) exposing `register(id, ref, worldPosFn)` / `unregister(id)`.
+- Inside `useFrameTick`: iterate registered markers, project, write `transform` and `visibility`.
+
+### TerritoryMarker
+
+```tsx
+function TerritoryMarker({ id }: { id: ID }) {
+  const ref = useRef<HTMLDivElement>(null);
+  const playerId = useGameStore(s => s.map.territory(id)?.playerId ?? null);
+  const hasAction = useGameStore(s => isLocationVisible(s.map, currentPlayer, id) && hasPlannedAction(s.map, id));
+
+  useMarkerRegistration(id, ref, () => getTerritoryAnchorWorld(id));
+
+  return (
+    <div ref={ref} className={styles.pill}>
+      <PlayerChip playerId={playerId} />
+      {hasAction && <span>A</span>}
+    </div>
+  );
+}
+```
+
+### UnitMarker
+
+```tsx
+function UnitMarker({ id }: { id: ID }) {
+  const ref = useRef<HTMLDivElement>(null);
+  const playerId  = useGameStore(s => s.map.unit(id)?.data.playerId ?? null);
+  const visible   = useGameStore(s => isUnitVisible(s.map, currentPlayer, id));
+  const moving    = useGameStore(s => s.map.unit(id)?.data.destinationId != null);
+  const defending = useGameStore(s => s.map.unit(id)?.data.statuses.includes(Values.Status.DEFEND) ?? false);
+  const starving  = useGameStore(s => s.map.unit(id)?.data.statuses.includes(Values.Status.STARVE) ?? false);
+
+  useMarkerRegistration(id, ref, () => getUnitAnchorWorld(id));
+
+  if (!visible) return null;
+
+  return (
+    <div ref={ref} className={styles.pill}>
+      <PlayerChip playerId={playerId} />
+      {moving && <span>M</span>}
+      {defending && <span>D</span>}
+      {starving && <span>S</span>}
+    </div>
+  );
+}
+```
+
+`PlayerChip` looks up player color + shape from `playerId` and renders the chip.
+
+## Implementation order
+
+1. Add `useFrameTick.ts` and `useBabylonObservable.ts` hooks.
+2. Add renderer accessors (`getTerritoryWorldPos`, `getUnitMesh`).
+3. Build `MarkerLayer` skeleton with placeholder square markers — verify projection, zoom-tracking, off-screen culling.
+4. Add `PlayerChip`, `TerritoryMarker`, `UnitMarker` with content selectors.
+5. Wire visibility filter into `UnitMarker` and territory `A` symbol.
+6. Slot `<MarkerLayer />` into `App.tsx` alongside `<Tooltip />`.
+7. Add idle optimisation: cached camera/viewport/registry/mapRevision state + early-out in the frame tick.
+8. Manual test in `yarn workspace @battles/gamev2 dev`:
+   - Hot-seat (visibility = `all`) with multiple players + units.
+   - API/local with `userId` set (fog of war).
+   - Replay scrubbing + camera animations + unit move animations.
+   - Idle: pan camera, stop, confirm projection loop bails out (log probe).
+9. Profile with Chrome DevTools Performance; verify no reconcile regression and zero work when idle.
+10. Update `packages/gamev2/AGENTS.md` with the integration pattern section.
+
+## Risks / open questions
+
+- **HiDPI scaling math** — exact conversion between `Vector3.Project` output and CSS pixels needs verification against real canvas layout. Likely a `1 / engine.getHardwareScalingLevel()` factor; confirm during impl.
+- **`hasPlannedAction` lookup** — depends on how planned territory actions are stored in the model (`territory.data.action`? a player-level map?). Resolve during impl by reading the relevant model code.
+- **Player color source** — `map.player(territory.playerId).data.colour` likely. Verify and centralise into a `colorFor(playerId)` helper.
+- **Marker overlap** — when many units share a territory, their markers may stack on the same screen point. The world-space offset puts them at the same anchor. Acceptable for v1; future enhancement could cascade markers vertically per stack.
+- **Unit grid arrangement during animations** — `UnitSyncer` arranges multiple units per location. Reading `mesh.getAbsolutePosition()` each frame already follows arrangement; no extra work needed.
+- **Babylon `Observable.remove` semantics** — confirm it accepts an `Observer` and that removing the wrong-mount observer is safe under StrictMode. The hook design only ever removes its own observer, so this should be fine.


### PR DESCRIPTION
## Purpose 🎯 

Make map comprehension easier with visible UI markers that summarise player control, type, and statuses (units: defend, moving, starve, and territories: action)

<img width="1920" height="1083" alt="image" src="https://github.com/user-attachments/assets/caa6f798-e2fb-4a37-a420-e9460ac8abbd" />

## Context 💭 

- added AGENTS.md
- refactored context to consolidate a couple providers
- add a missing tooltip hover for unit types