### PR TITLE
fix: redirect home `/` to `/lobby/`

### DIFF
--- a/packages/game/assets/html/index.html
+++ b/packages/game/assets/html/index.html
@@ -14,7 +14,7 @@
   </div>
 
   <!-- Main -->
-  <script src="/build/bundle/vendor.bundle.js"></script>
-  <script src="/build/bundle/model.bundle.js"></script>
-  <script src="/build/bundle/game.bundle.js"></script>
+  <script src="/v1/build/bundle/vendor.bundle.js"></script>
+  <script src="/v1/build/bundle/model.bundle.js"></script>
+  <script src="/v1/build/bundle/game.bundle.js"></script>
 </body>

--- a/packages/game/assets/html/lobby.html
+++ b/packages/game/assets/html/lobby.html
@@ -11,7 +11,7 @@
   </div>
 
   <!-- Main -->
-  <script src="/build/bundle/vendor.bundle.js"></script>
-  <script src="/build/bundle/model.bundle.js"></script>
-  <script src="/build/bundle/lobby.bundle.js"></script>
+  <script src="/v1/build/bundle/vendor.bundle.js"></script>
+  <script src="/v1/build/bundle/model.bundle.js"></script>
+  <script src="/v1/build/bundle/lobby.bundle.js"></script>
 </body>

--- a/packages/game/assets/html/mobx.html
+++ b/packages/game/assets/html/mobx.html
@@ -86,8 +86,8 @@
   <div id="phaser-container">
   </div>
   <!-- Main -->
-  <script src="/build/es5/test.js"></script>
-  <script src="/build/bundle/vendor.bundle.js"></script>
-  <!-- <script src="/build/bundle/model.bundle.js"></script> -->
-  <script src="/build/bundle/mobx.bundle.js"></script>
+  <script src="/v1/build/es5/test.js"></script>
+  <script src="/v1/build/bundle/vendor.bundle.js"></script>
+  <!-- <script src="/v1/build/bundle/model.bundle.js"></script> -->
+  <script src="/v1/build/bundle/mobx.bundle.js"></script>
 </body>

--- a/packages/ops/lib/app-stack.ts
+++ b/packages/ops/lib/app-stack.ts
@@ -34,11 +34,17 @@ export class AppStack extends cdk.Stack {
       code: cloudfront.FunctionCode.fromInline(`
         function handler(event) {
           var uri = event.request.uri;
+          // Redirect site root to the standalone lobby app
           if (uri === '/' || uri === '') {
             return { statusCode: 302, statusDescription: 'Found', headers: { location: { value: '/lobby/' } } };
           }
+          // Redirect /v1 root to the legacy v1 lobby page
           if (uri === '/v1' || uri === '/v1/') {
             return { statusCode: 302, statusDescription: 'Found', headers: { location: { value: '/v1/lobby.html' } } };
+          }
+          // Rewrite directory requests to index.html — S3 (OAC) has no directory index
+          if (uri.endsWith('/')) {
+            event.request.uri = uri + 'index.html';
           }
           return event.request;
         }

--- a/packages/ops/lib/app-stack.ts
+++ b/packages/ops/lib/app-stack.ts
@@ -30,10 +30,31 @@ export class AppStack extends cdk.Stack {
       validation: acm.CertificateValidation.fromDns(zone),
     });
 
+    const redirectFunction = new cloudfront.Function(this, "RedirectFunction", {
+      code: cloudfront.FunctionCode.fromInline(`
+        function handler(event) {
+          var uri = event.request.uri;
+          if (uri === '/' || uri === '') {
+            return { statusCode: 302, statusDescription: 'Found', headers: { location: { value: '/lobby/' } } };
+          }
+          if (uri === '/v1' || uri === '/v1/') {
+            return { statusCode: 302, statusDescription: 'Found', headers: { location: { value: '/v1/lobby.html' } } };
+          }
+          return event.request;
+        }
+      `),
+    });
+
     const distribution = new cloudfront.Distribution(this, "Distribution", {
-      defaultRootObject: "lobby.html",
+      defaultRootObject: "index.html",
       defaultBehavior: {
         origin: origins.S3BucketOrigin.withOriginAccessControl(bucket),
+        functionAssociations: [
+          {
+            function: redirectFunction,
+            eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
+          },
+        ],
       },
       domainNames: [hostname],
       certificate,
@@ -53,11 +74,8 @@ export class AppStack extends cdk.Stack {
     new s3deployment.BucketDeployment(this, "DeployApp", {
       sources: [s3deployment.Source.asset(DEPLOYMENT_ARTIFACT_GAME)],
       destinationBucket: bucket,
+      destinationKeyPrefix: "v1/",
       distribution,
-      exclude: [
-        "v2/*",
-        "lobby/*"
-      ]
     });
 
     new s3deployment.BucketDeployment(this, "DeployGameV2", {

--- a/specs/refactor-lobby-redirect.md
+++ b/specs/refactor-lobby-redirect.md
@@ -1,0 +1,45 @@
+# Refactor: Move v1 game to /v1/, redirect / → /lobby/
+
+## Context
+
+Originally the v1 game client + lobby were deployed to the S3 bucket root, with `defaultRootObject: "lobby.html"` so visiting the site served the v1 legacy lobby. Since then, a standalone lobby app (`@battles/lobby`) was created at `/lobby/`, and gamev2 lives at `/v2/`. The v1 game is now legacy but should remain accessible at `/v1/` rather than cluttering the root. Visiting `/` should 302 redirect to the new standalone lobby at `/lobby/`.
+
+302 (temporary) redirect chosen over 301 so browsers don't hard-cache and the target can be changed later.
+
+## Changes
+
+### 1. `packages/ops/lib/app-stack.ts`
+
+**a.** Set `defaultRootObject: "index.html"` (semantic default; redirect function takes priority for `/`).
+
+**b.** Add a CloudFront Function for viewer-request that handles redirects:
+- `/` or `` → 302 to `/lobby/`
+- `/v1` or `/v1/` → 302 to `/v1/lobby.html`
+
+Attach to `defaultBehavior` via `functionAssociations` with `FunctionEventType.VIEWER_REQUEST`.
+
+**c.** Change `DeployApp` S3 deployment: add `destinationKeyPrefix: "v1/"`, remove `exclude` array (no longer needed — v1 is isolated in its own prefix).
+
+### 2. `packages/game/assets/html/index.html`
+
+Change `/build/bundle/` → `/v1/build/bundle/` (script src paths)
+
+### 3. `packages/game/assets/html/lobby.html`
+
+Change `/build/bundle/` → `/v1/build/bundle/` (script src paths)
+
+### 4. `packages/game/assets/html/mobx.html`
+
+Change `/build/bundle/` → `/v1/build/bundle/` and `/build/es5/` → `/v1/build/es5/`
+
+## Not changed
+
+- `pipeline-stack.ts` — build commands unchanged
+- `packages/game/package.json` `package` script — zip structure unchanged; paths correct once HTML updated
+- `ops.test.ts` — tests `ApiStack` only, unaffected
+
+## Verification
+
+1. `yarn workspace @battles/ops cdk synth` — confirm synth succeeds
+2. `yarn workspace @battles/ops test` — confirm ops tests still pass
+3. Inspect `cdk.out/` CloudFormation: `defaultRootObject` = `index.html`, CloudFront Function present, `DeployApp` has `destinationKeyPrefix: v1/`


### PR DESCRIPTION
## Purpose 🎯

Redirect root `/` to `/lobby/` app

Deploy legacy app to `/v1/` instead of root 

## Context 💭

Also default `index.html` at non-root directory style paths (ending in `/`)